### PR TITLE
[EDO-208] Missing person breaks application

### DIFF
--- a/src/main/webapp/app/shared/teams-selection/teams-selection.service.ts
+++ b/src/main/webapp/app/shared/teams-selection/teams-selection.service.ts
@@ -24,6 +24,7 @@ export class TeamsSelectionService {
                     this._selectedTeam = result.body || null;
                 })
                 .catch(err => {
+                    this.selectedTeam = null;
                     return Observable.empty();
                 })
                 .flatMap((result: any) => {

--- a/src/main/webapp/app/shared/teams-selection/teams-selection.service.ts
+++ b/src/main/webapp/app/shared/teams-selection/teams-selection.service.ts
@@ -23,10 +23,10 @@ export class TeamsSelectionService {
                 .do(result => {
                     this._selectedTeam = result.body || null;
                 })
-                .flatMap(result => {
+                .flatMap((result: any) => {
                     return this.teamSkillService
                         .query({ 'teamId.equals': result.body.id })
-                        .do(teamSkillRes => {
+                        .do((teamSkillRes: any) => {
                             this._selectedTeam.skills = teamSkillRes.body || [];
                         })
                         .map(() => result.body);

--- a/src/main/webapp/app/shared/teams-selection/teams-selection.service.ts
+++ b/src/main/webapp/app/shared/teams-selection/teams-selection.service.ts
@@ -23,6 +23,9 @@ export class TeamsSelectionService {
                 .do(result => {
                     this._selectedTeam = result.body || null;
                 })
+                .catch(err => {
+                    return Observable.empty();
+                })
                 .flatMap((result: any) => {
                     return this.teamSkillService
                         .query({ 'teamId.equals': result.body.id })


### PR DESCRIPTION
Some linting and the actual fix to handle person ids not matching any person in the backend. If it is the case, no person gets selected. The item in local storage holding the wrong information about a selected person is not updated but can easily be overwritten by reselecting a person.