### PR TITLE
[EDO-163] Use multiline input for long entity fields

### DIFF
--- a/src/main/webapp/app/entities/skill/skill-update.component.html
+++ b/src/main/webapp/app/entities/skill/skill-update.component.html
@@ -52,8 +52,8 @@
                 </div>
                 <div class="form-group">
                     <label class="form-control-label" jhiTranslate="teamdojoApp.skill.validation" for="field_validation">Validation</label>
-                    <input type="text" class="form-control" name="validation" id="field_validation"
-                        [(ngModel)]="skill.validation" maxlength="2048"/>
+                    <textarea class="form-control" name="validation" id="field_validation"
+                              [(ngModel)]="skill.validation" rows="3" maxlength="2048"></textarea>
                     <div [hidden]="!(editForm.controls.validation?.dirty && editForm.controls.validation?.invalid)">
                         <small class="form-text text-danger"
                         [hidden]="!editForm.controls.validation?.errors?.maxlength" jhiTranslate="entity.validation.maxlength" translateValues="{ max: 2048 }">

--- a/src/main/webapp/app/entities/skill/skill-update.component.html
+++ b/src/main/webapp/app/entities/skill/skill-update.component.html
@@ -41,8 +41,8 @@
                 </div>
                 <div class="form-group">
                     <label class="form-control-label" jhiTranslate="teamdojoApp.skill.implementation" for="field_implementation">Implementation</label>
-                    <input type="text" class="form-control" name="implementation" id="field_implementation"
-                        [(ngModel)]="skill.implementation" maxlength="2048"/>
+                    <textarea class="form-control" name="implementation" id="field_implementation"
+                              [(ngModel)]="skill.implementation" rows="3" maxlength="2048"></textarea>
                     <div [hidden]="!(editForm.controls.implementation?.dirty && editForm.controls.implementation?.invalid)">
                         <small class="form-text text-danger"
                         [hidden]="!editForm.controls.implementation?.errors?.maxlength" jhiTranslate="entity.validation.maxlength" translateValues="{ max: 2048 }">

--- a/src/main/webapp/app/entities/skill/skill-update.component.html
+++ b/src/main/webapp/app/entities/skill/skill-update.component.html
@@ -30,8 +30,8 @@
                 </div>
                 <div class="form-group">
                     <label class="form-control-label" jhiTranslate="teamdojoApp.skill.description" for="field_description">Description</label>
-                    <input type="text" class="form-control" name="description" id="field_description"
-                        [(ngModel)]="skill.description" maxlength="2048"/>
+                    <textarea class="form-control" name="description" id="field_description"
+                              [(ngModel)]="skill.description" rows="3" maxlength="2048"></textarea>
                     <div [hidden]="!(editForm.controls.description?.dirty && editForm.controls.description?.invalid)">
                         <small class="form-text text-danger"
                         [hidden]="!editForm.controls.description?.errors?.maxlength" jhiTranslate="entity.validation.maxlength" translateValues="{ max: 2048 }">


### PR DESCRIPTION
Used report description as a blueprint to switch from inputs to textareas for some fields when editing skill entity.