### PR TITLE
[EDO-215] Use Placeholder to show examples of expiry period syntax

### DIFF
--- a/src/main/webapp/app/entities/skill/skill-update.component.html
+++ b/src/main/webapp/app/entities/skill/skill-update.component.html
@@ -64,7 +64,8 @@
                 <div class="form-group">
                     <label class="form-control-label" jhiTranslate="teamdojoApp.skill.expiryPeriod" for="field_expiryPeriod">Expiry Period</label>
                     <input type="text" class="form-control" name="expiryPeriod" id="field_expiryPeriod"
-                        [(ngModel)]="skill.expiryPeriod" pattern="^P(?:([-+]?[0-9]+)Y)?(?:([-+]?[0-9]+)M)?(?:([-+]?[0-9]+)W)?(?:([-+]?[0-9]+)D)?$"/>
+                        [(ngModel)]="skill.expiryPeriod" pattern="^P(?:([-+]?[0-9]+)Y)?(?:([-+]?[0-9]+)M)?(?:([-+]?[0-9]+)W)?(?:([-+]?[0-9]+)D)?$"
+                        [placeholder]="'teamdojoApp.skill.expiryPeriodPlaceholder' | translate"/>
                     <div [hidden]="!(editForm.controls.expiryPeriod?.dirty && editForm.controls.expiryPeriod?.invalid)">
                         <small class="form-text text-danger"
                             [hidden]="!editForm.controls.expiryPeriod?.errors?.pattern" jhiTranslate="entity.validation.pattern" translateValues="{ pattern: 'Expiry Period' }">

--- a/src/main/webapp/app/entities/skill/skill-update.component.html
+++ b/src/main/webapp/app/entities/skill/skill-update.component.html
@@ -71,6 +71,11 @@
                             [hidden]="!editForm.controls.expiryPeriod?.errors?.pattern" jhiTranslate="entity.validation.pattern" translateValues="{ pattern: 'Expiry Period' }">
                             This field should follow pattern for "Expiry Period".
                         </small>
+                        <small class="form-text text-danger"
+                               [hidden]="!editForm.controls.expiryPeriod?.errors?.pattern" jhiTranslate="entity.validation.expectedPattern"
+                               translateValues="{ regex: '/^P(?:([-+]?[0-9]+)Y)?(?:([-+]?[0-9]+)M)?(?:([-+]?[0-9]+)W)?(?:([-+]?[0-9]+)D)?$/' }">
+                            The expected pattern is /^P(?:([-+]?[0-9]+)Y)?(?:([-+]?[0-9]+)M)?(?:([-+]?[0-9]+)W)?(?:([-+]?[0-9]+)D)?$/.
+                        </small>
                     </div>
                 </div>
                 <div class="form-group">

--- a/src/main/webapp/i18n/de/global.json
+++ b/src/main/webapp/i18n/de/global.json
@@ -139,6 +139,7 @@
             "minbytes": "Dieses Feld sollte mehr als {{min}} bytes haben.",
             "maxbytes": "Dieses Feld sollte nicht mehr als {{max}} bytes haben.",
             "pattern": "Dieses Feld muss das Muster {{pattern}} erfüllen.",
+            "expectedPattern": "Das erwartete Muster ist {{ regex }}.",
             "number": "Dieses Feld muss eine Zahl sein.",
             "datetimelocal": "Dieses Feld muss eine Datums- und Zeitangabe enthalten."
         }

--- a/src/main/webapp/i18n/de/skill.json
+++ b/src/main/webapp/i18n/de/skill.json
@@ -25,6 +25,7 @@
             "implementation": "Implementation",
             "validation": "Validation",
             "expiryPeriod": "Expiry Period",
+            "expiryPeriodPlaceholder": "z.B. P1Y6M1W2D oder P6M-1D",
             "contact": "Contact",
             "score": "Score",
             "rateScore": "Rate Score",

--- a/src/main/webapp/i18n/de_person/global.json
+++ b/src/main/webapp/i18n/de_person/global.json
@@ -139,6 +139,7 @@
             "minbytes": "Dieses Feld sollte mehr als {{min}} bytes haben.",
             "maxbytes": "Dieses Feld sollte nicht mehr als {{max}} bytes haben.",
             "pattern": "Dieses Feld muss das Muster {{pattern}} erfüllen.",
+            "expectedPattern": "Das erwartete Muster ist {{ regex }}.",
             "number": "Dieses Feld muss eine Zahl sein.",
             "datetimelocal": "Dieses Feld muss eine Datums- und Zeitangabe enthalten."
         }

--- a/src/main/webapp/i18n/de_person/skill.json
+++ b/src/main/webapp/i18n/de_person/skill.json
@@ -25,6 +25,7 @@
             "implementation": "Implementation",
             "validation": "Validation",
             "expiryPeriod": "Expiry Period",
+            "expiryPeriodPlaceholder": "z.B. P1Y6M1W2D oder P6M-1D",
             "contact": "Contact",
             "score": "Score",
             "rateScore": "Rate Score",

--- a/src/main/webapp/i18n/en/global.json
+++ b/src/main/webapp/i18n/en/global.json
@@ -139,6 +139,7 @@
             "minbytes": "This field should be at least {{ min }} bytes.",
             "maxbytes": "This field cannot be more than {{ max }} bytes.",
             "pattern": "This field should follow pattern for {{ pattern }}.",
+            "expectedPattern": "The expected pattern is {{ regex }}.",
             "number": "This field should be a number.",
             "datetimelocal": "This field should be a date and time.",
             "patternLogin": "This field can only contain letters, digits and e-mail addresses."

--- a/src/main/webapp/i18n/en/skill.json
+++ b/src/main/webapp/i18n/en/skill.json
@@ -25,6 +25,7 @@
             "implementation": "Implementation",
             "validation": "Validation",
             "expiryPeriod": "Expiry Period",
+            "expiryPeriodPlaceholder": "e.g. P1Y6M1W2D or P6M-1D",
             "contact": "Contact",
             "score": "Score",
             "rateScore": "Rate Score",

--- a/src/main/webapp/i18n/en_person/global.json
+++ b/src/main/webapp/i18n/en_person/global.json
@@ -139,6 +139,7 @@
             "minbytes": "This field should be at least {{ min }} bytes.",
             "maxbytes": "This field cannot be more than {{ max }} bytes.",
             "pattern": "This field should follow pattern for {{ pattern }}.",
+            "expectedPattern": "The expected pattern is {{ regex }}.",
             "number": "This field should be a number.",
             "datetimelocal": "This field should be a date and time.",
             "patternLogin": "This field can only contain letters, digits and e-mail addresses."

--- a/src/main/webapp/i18n/en_person/skill.json
+++ b/src/main/webapp/i18n/en_person/skill.json
@@ -25,6 +25,7 @@
             "implementation": "Implementation",
             "validation": "Validation",
             "expiryPeriod": "Expiry Period",
+            "expiryPeriodPlaceholder": "e.g. P1Y6M1W2D or P6M-1D",
             "contact": "Contact",
             "score": "Score",
             "rateScore": "Rate Score",


### PR DESCRIPTION
Use two different examples to show what an expiry period can be and display them in the input field as a placeholder. When validation fails show the expected pattern additionally. i18n is included.

The actual property is not used in the business logic at the moment.