### PR TITLE
[EDO-168] Show all skills in overview

### DIFF
--- a/src/main/webapp/app/overview/skills/overview-skills.component.html
+++ b/src/main/webapp/app/overview/skills/overview-skills.component.html
@@ -20,16 +20,16 @@
         <li class="list-group-item list-group-item-action flex-column align-items-start mb-2 skill-container"
             [ngClass]="{'active-skill':isActiveSkill(skill)}"
             *ngFor="let skill of activeSkills | skillFilter:search"
-            [routerLink]="['/overview', 'skills', skill.skillId]" [queryParams]="{level: activeLevel?.id, badge: activeBadge?.id}">
+            [routerLink]="['/overview', 'skills', skill.id]" [queryParams]="{level: activeLevel?.id, badge: activeBadge?.id}">
             <div class="d-flex justify-content-between">
-                <a class="#" class="text-dark mb-1 skill-title" >{{ skill.skillTitle }}</a>
+                <a class="#" class="text-dark mb-1 skill-title" >{{ skill.title }}</a>
                 <div class="d-flex align-items-end ml-auto count-teams">
                     <span class="mb-auto">{{getRelevantTeams(skill)}}</span>
                 </div>
             </div>
-            <ngb-rating [(rate)]="findSkill(skill.skillId).rateScore" max="5" [readonly]="true" [starTemplate]="stars">
+            <ngb-rating [(rate)]="findSkill(skill.id).rateScore" max="5" [readonly]="true" [starTemplate]="stars">
             </ngb-rating>
-            {{getRateCount(findSkill(skill.skillId).rateCount)}} <span class="rating-text" jhiTranslate="teamdojoApp.skill.detail.rateCount"></span>
+            {{getRateCount(findSkill(skill.id).rateCount)}} <span class="rating-text" jhiTranslate="teamdojoApp.skill.detail.rateCount"></span>
 
             <ng-template #stars let-fill="fill" let-index="index">
                 <span class="star star-sm" [class.full]="fill === 100">

--- a/src/main/webapp/app/overview/skills/overview-skills.component.ts
+++ b/src/main/webapp/app/overview/skills/overview-skills.component.ts
@@ -58,22 +58,17 @@ export class OverviewSkillsComponent implements OnInit, OnChanges {
                 this.activeBadge = null;
                 if (params.get('level')) {
                     this.activeLevel = (this.levels || []).find((level: ILevel) => level.id === Number.parseInt(params.get('level')));
-                    this.activeSkills = this.sortActiveSkills(
-                        this.activeLevel ? this.activeLevel.skills.filter(l => this.isCompleted(l)) : []
-                    );
+                    this.activeSkills = this.activeLevel ? this.sortActiveSkills(this.activeLevel.skills) : [];
                     this.updateBreadcrumb();
                 } else if (params.get('badge')) {
                     this.activeBadge = (this.badges || []).find((badge: IBadge) => badge.id === Number.parseInt(params.get('badge')));
-                    this.activeSkills = this.sortActiveSkills(
-                        this.activeBadge ? this.activeBadge.skills.filter(l => this.isCompleted(l)) : []
-                    );
+                    this.activeSkills = this.activeBadge ? this.sortActiveSkills(this.activeBadge.skills) : [];
                     this.updateBreadcrumb();
                 } else {
                     this.activeSkills = this.sortActiveSkills(
-                        (this.levelSkills.filter(l => this.isCompleted(l)) || []).concat(
-                            this.badgeSkills
-                                .filter((b: IBadgeSkill) => !this.levelSkills.find((l: ILevelSkill) => l.skillId === b.skillId))
-                                .filter(l => this.isCompleted(l)) || []
+                        (this.levelSkills || []).concat(
+                            this.badgeSkills.filter((b: IBadgeSkill) => !this.levelSkills.find((l: ILevelSkill) => l.skillId === b.skillId)) ||
+                                []
                         )
                     );
                     this.updateBreadcrumb();
@@ -183,16 +178,6 @@ export class OverviewSkillsComponent implements OnInit, OnChanges {
 
     findSkill(skillId: number): ISkill {
         return (this.skills || []).find(skill => skill.id === skillId);
-    }
-
-    private isCompleted(skill: ILevelSkill | IBadgeSkill): boolean {
-        for (const team of this.teams) {
-            const teamSkill = this.findTeamSkill(team, skill);
-            if (this.isTeamSkillCompleted(teamSkill)) {
-                return true;
-            }
-        }
-        return false;
     }
 
     private findTeamSkill(team: ITeam, skill: ILevelSkill | IBadgeSkill): ITeamSkill {

--- a/src/main/webapp/app/overview/skills/overview-skills.component.ts
+++ b/src/main/webapp/app/overview/skills/overview-skills.component.ts
@@ -29,7 +29,8 @@ export class OverviewSkillsComponent implements OnInit, OnChanges {
     badges: IBadge[];
     badgeSkills: IBadgeSkill[];
     skills: ISkill[];
-    activeSkills: ILevelSkill[] | IBadgeSkill[];
+    activeSkills: ISkill[];
+    itemSkills: ILevelSkill[] | IBadgeSkill[];
     activeLevel: ILevel;
     activeBadge: IBadge;
     dimensionsBySkillId: any;
@@ -58,18 +59,19 @@ export class OverviewSkillsComponent implements OnInit, OnChanges {
                 this.activeBadge = null;
                 if (params.get('level')) {
                     this.activeLevel = (this.levels || []).find((level: ILevel) => level.id === Number.parseInt(params.get('level')));
-                    this.activeSkills = this.activeLevel ? this.sortActiveSkills(this.activeLevel.skills) : [];
+                    this.activeSkills = this.activeLevel ? this.sortActiveSkills(this.findSkills(this.activeLevel.skills)) : [];
+                    this.itemSkills = this.activeLevel.skills || [];
                     this.updateBreadcrumb();
                 } else if (params.get('badge')) {
                     this.activeBadge = (this.badges || []).find((badge: IBadge) => badge.id === Number.parseInt(params.get('badge')));
-                    this.activeSkills = this.activeBadge ? this.sortActiveSkills(this.activeBadge.skills) : [];
+                    this.activeSkills = this.activeBadge ? this.sortActiveSkills(this.findSkills(this.activeBadge.skills)) : [];
+                    this.itemSkills = this.activeBadge.skills || [];
                     this.updateBreadcrumb();
                 } else {
-                    this.activeSkills = this.sortActiveSkills(
-                        (this.levelSkills || []).concat(
-                            this.badgeSkills.filter((b: IBadgeSkill) => !this.levelSkills.find((l: ILevelSkill) => l.skillId === b.skillId)) ||
-                                []
-                        )
+                    this.activeSkills = this.sortActiveSkills(this.skills);
+                    this.itemSkills = (this.levelSkills || []).concat(
+                        this.badgeSkills.filter((b: IBadgeSkill) => !this.levelSkills.find((l: ILevelSkill) => l.skillId === b.skillId)) ||
+                            []
                     );
                     this.updateBreadcrumb();
                 }
@@ -85,16 +87,6 @@ export class OverviewSkillsComponent implements OnInit, OnChanges {
                 this.search = value;
                 return value;
             });
-    }
-
-    onSkillSort() {
-        this.activeSkills = this.sortActiveSkills(this.activeSkills);
-    }
-
-    sortActiveSkills(activeSkills = []) {
-        return (
-            new SkillSortPipe().transform((activeSkills || []).map(activeSkill => this.findSkill(activeSkill.skillId)), this.orderBy) || []
-        ).map(skill => activeSkills.find(activeSkill => activeSkill.skillId === skill.id));
     }
 
     loadAll() {
@@ -149,28 +141,28 @@ export class OverviewSkillsComponent implements OnInit, OnChanges {
         this.jhiAlertService.error(errorMessage, null, null);
     }
 
-    getRelevantTeams(itemSkill: ILevelSkill | IBadgeSkill): string {
+    getRelevantTeams(skill: ISkill): string {
         const countProgress = new Progress(0, 0);
         for (const team of this.teams) {
-            const teamSkill = this.findTeamSkill(team, itemSkill);
-            if (this.isRelevantSkill(team, teamSkill, itemSkill)) {
+            const teamSkill = this.findTeamSkill(team, skill);
+            if (this.isRelevantSkill(team, teamSkill, skill)) {
                 countProgress.required++;
                 if (this.isTeamSkillCompleted(teamSkill)) {
                     countProgress.achieved++;
                 }
             }
         }
-        if (this.generalSkillsIds.indexOf(itemSkill.id) !== -1) {
+        if (this.generalSkillsIds.indexOf(skill.id) !== -1) {
             countProgress.required = this.teams.length;
         }
         return `${countProgress.achieved}  / ${countProgress.required}`;
     }
 
-    private isRelevantSkill(team: ITeam, teamSkill: ITeamSkill, itemSkill: ILevelSkill | IBadgeSkill) {
+    private isRelevantSkill(team: ITeam, teamSkill: ITeamSkill, skill: ISkill) {
         if (teamSkill && teamSkill.irrelevant) {
             return false;
         }
-        const skillDimensionIds = this.dimensionsBySkillId[itemSkill.skillId] || [];
+        const skillDimensionIds = this.dimensionsBySkillId[skill.id] || [];
         return team.participations.some(dimension => {
             return skillDimensionIds.indexOf(dimension.id) !== -1;
         });
@@ -180,19 +172,35 @@ export class OverviewSkillsComponent implements OnInit, OnChanges {
         return (this.skills || []).find(skill => skill.id === skillId);
     }
 
-    private findTeamSkill(team: ITeam, skill: ILevelSkill | IBadgeSkill): ITeamSkill {
-        return team.skills ? team.skills.find((teamSkill: ITeamSkill) => teamSkill.skillId === skill.skillId) : null;
+    findSkills(itemSkills): ISkill[] {
+        return (itemSkills || []).map((itemSkill: ILevelSkill | IBadgeSkill) =>
+            (this.skills || []).find(skill => itemSkill.skillId === skill.id)
+        );
+    }
+
+    private findTeamSkill(team: ITeam, skill: ISkill): ITeamSkill {
+        return team.skills ? team.skills.find((teamSkill: ITeamSkill) => teamSkill.skillId === skill.id) : null;
     }
 
     private isTeamSkillCompleted(teamSkill: ITeamSkill): boolean {
         return teamSkill && !!teamSkill.completedAt;
     }
 
-    isActiveSkill(iLevelSkill: ILevelSkill) {
-        return typeof this.activeSkill !== 'undefined' && this.activeSkill !== null && this.activeSkill.id === iLevelSkill.skillId;
+    isActiveSkill(skill: ISkill) {
+        return typeof this.activeSkill !== 'undefined' && this.activeSkill !== null && this.activeSkill.id === skill.id;
     }
 
     getRateCount(rateCount: number) {
         return rateCount !== null && typeof rateCount !== 'undefined' ? rateCount : 0;
+    }
+
+    onSkillSort() {
+        this.activeSkills = this.sortActiveSkills(this.activeSkills);
+    }
+
+    sortActiveSkills(activeSkills = []) {
+        return (
+            new SkillSortPipe().transform((activeSkills || []).map(activeSkill => this.findSkill(activeSkill.id)), this.orderBy) || []
+        ).map(skill => activeSkills.find(activeSkill => activeSkill.id === skill.id));
     }
 }

--- a/src/main/webapp/app/overview/skills/overview-skills.component.ts
+++ b/src/main/webapp/app/overview/skills/overview-skills.component.ts
@@ -112,11 +112,9 @@ export class OverviewSkillsComponent implements OnInit, OnChanges {
                     const skillId = badgeSkill.skillId;
                     this.dimensionsBySkillId[skillId] = this.dimensionsBySkillId[skillId] || [];
 
-                    this.dimensionsBySkillId[skillId].forEach(entry => {
-                        if (entry.indexOf(skillId) === -1) {
-                            this.dimensionsBySkillId[skillId].push(dimension.id);
-                        }
-                    });
+                    if (this.dimensionsBySkillId[skillId].indexOf(dimension.id) === -1) {
+                        this.dimensionsBySkillId[skillId].push(dimension.id);
+                    }
                 });
             });
         });


### PR DESCRIPTION
Previously only skills completed by at least one team were shown in overview. With this change every skill is navigable as a normal user in the application. While working on this a bug regarding counting of relevant teams for skills associated to badges of a dimension has been fixed, too.