### PR TITLE
[EDO-162] make comment list sortable in admin view

### DIFF
--- a/.jhipster/Comment.json
+++ b/.jhipster/Comment.json
@@ -42,5 +42,5 @@
     "service": "serviceImpl",
     "entityTableName": "comment",
     "jpaMetamodelFiltering": true,
-    "pagination": "no"
+    "pagination": "infinite-scroll"
 }

--- a/src/main/java/de/otto/teamdojo/domain/Comment.java
+++ b/src/main/java/de/otto/teamdojo/domain/Comment.java
@@ -5,7 +5,8 @@ import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 
 import javax.persistence.*;
-import javax.validation.constraints.NotNull;
+import javax.validation.constraints.*;
+
 import java.io.Serializable;
 import java.time.Instant;
 import java.util.Objects;

--- a/src/main/java/de/otto/teamdojo/repository/CommentRepository.java
+++ b/src/main/java/de/otto/teamdojo/repository/CommentRepository.java
@@ -1,9 +1,8 @@
 package de.otto.teamdojo.repository;
 
 import de.otto.teamdojo.domain.Comment;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
+import org.springframework.data.jpa.repository.*;
 
 /**
  * Spring Data JPA repository for the Comment entity.

--- a/src/main/java/de/otto/teamdojo/service/CommentQueryService.java
+++ b/src/main/java/de/otto/teamdojo/service/CommentQueryService.java
@@ -1,14 +1,7 @@
 package de.otto.teamdojo.service;
 
-import de.otto.teamdojo.domain.Comment;
-import de.otto.teamdojo.domain.Comment_;
-import de.otto.teamdojo.domain.Skill_;
-import de.otto.teamdojo.domain.Team_;
-import de.otto.teamdojo.repository.CommentRepository;
-import de.otto.teamdojo.service.dto.CommentCriteria;
-import de.otto.teamdojo.service.dto.CommentDTO;
-import de.otto.teamdojo.service.mapper.CommentMapper;
-import io.github.jhipster.service.QueryService;
+import java.util.List;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Page;
@@ -17,7 +10,15 @@ import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
+import io.github.jhipster.service.QueryService;
+
+import de.otto.teamdojo.domain.Comment;
+import de.otto.teamdojo.domain.*; // for static metamodels
+import de.otto.teamdojo.repository.CommentRepository;
+import de.otto.teamdojo.service.dto.CommentCriteria;
+
+import de.otto.teamdojo.service.dto.CommentDTO;
+import de.otto.teamdojo.service.mapper.CommentMapper;
 
 /**
  * Service for executing complex queries for Comment entities in the database.
@@ -42,7 +43,6 @@ public class CommentQueryService extends QueryService<Comment> {
 
     /**
      * Return a {@link List} of {@link CommentDTO} which matches the criteria from the database
-     *
      * @param criteria The object which holds all the filters, which the entities should match.
      * @return the matching entities.
      */
@@ -55,9 +55,8 @@ public class CommentQueryService extends QueryService<Comment> {
 
     /**
      * Return a {@link Page} of {@link CommentDTO} which matches the criteria from the database
-     *
      * @param criteria The object which holds all the filters, which the entities should match.
-     * @param page     The page, which should be returned.
+     * @param page The page, which should be returned.
      * @return the matching entities.
      */
     @Transactional(readOnly = true)

--- a/src/main/java/de/otto/teamdojo/service/CommentService.java
+++ b/src/main/java/de/otto/teamdojo/service/CommentService.java
@@ -2,7 +2,9 @@ package de.otto.teamdojo.service;
 
 import de.otto.teamdojo.service.dto.CommentDTO;
 
-import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 import java.util.Optional;
 
 /**
@@ -21,9 +23,10 @@ public interface CommentService {
     /**
      * Get all the comments.
      *
+     * @param pageable the pagination information
      * @return the list of entities
      */
-    List<CommentDTO> findAll();
+    Page<CommentDTO> findAll(Pageable pageable);
 
 
     /**

--- a/src/main/java/de/otto/teamdojo/service/dto/CommentCriteria.java
+++ b/src/main/java/de/otto/teamdojo/service/dto/CommentCriteria.java
@@ -1,11 +1,18 @@
 package de.otto.teamdojo.service.dto;
 
+import java.io.Serializable;
+
+import io.github.jhipster.service.filter.BooleanFilter;
+import io.github.jhipster.service.filter.DoubleFilter;
 import io.github.jhipster.service.filter.Filter;
-import io.github.jhipster.service.filter.InstantFilter;
+import io.github.jhipster.service.filter.FloatFilter;
+import io.github.jhipster.service.filter.IntegerFilter;
 import io.github.jhipster.service.filter.LongFilter;
 import io.github.jhipster.service.filter.StringFilter;
 
-import java.io.Serializable;
+import io.github.jhipster.service.filter.InstantFilter;
+
+
 
 
 /**

--- a/src/main/java/de/otto/teamdojo/service/dto/CommentDTO.java
+++ b/src/main/java/de/otto/teamdojo/service/dto/CommentDTO.java
@@ -1,8 +1,8 @@
 package de.otto.teamdojo.service.dto;
 
-import javax.validation.constraints.NotNull;
-import java.io.Serializable;
 import java.time.Instant;
+import javax.validation.constraints.*;
+import java.io.Serializable;
 import java.util.Objects;
 
 /**

--- a/src/main/java/de/otto/teamdojo/service/impl/CommentServiceImpl.java
+++ b/src/main/java/de/otto/teamdojo/service/impl/CommentServiceImpl.java
@@ -8,13 +8,13 @@ import de.otto.teamdojo.service.mapper.CommentMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.stream.Collectors;
+
 /**
  * Service Implementation for managing Comment.
  */
@@ -50,15 +50,15 @@ public class CommentServiceImpl implements CommentService {
     /**
      * Get all the comments.
      *
+     * @param pageable the pagination information
      * @return the list of entities
      */
     @Override
     @Transactional(readOnly = true)
-    public List<CommentDTO> findAll() {
+    public Page<CommentDTO> findAll(Pageable pageable) {
         log.debug("Request to get all Comments");
-        return commentRepository.findAll().stream()
-            .map(commentMapper::toDto)
-            .collect(Collectors.toCollection(LinkedList::new));
+        return commentRepository.findAll(pageable)
+            .map(commentMapper::toDto);
     }
 
 

--- a/src/main/java/de/otto/teamdojo/service/mapper/CommentMapper.java
+++ b/src/main/java/de/otto/teamdojo/service/mapper/CommentMapper.java
@@ -1,9 +1,9 @@
 package de.otto.teamdojo.service.mapper;
 
-import de.otto.teamdojo.domain.Comment;
+import de.otto.teamdojo.domain.*;
 import de.otto.teamdojo.service.dto.CommentDTO;
-import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
+
+import org.mapstruct.*;
 
 /**
  * Mapper for the entity Comment and its DTO CommentDTO.

--- a/src/main/java/de/otto/teamdojo/web/rest/CommentResource.java
+++ b/src/main/java/de/otto/teamdojo/web/rest/CommentResource.java
@@ -1,21 +1,27 @@
 package de.otto.teamdojo.web.rest;
 
 import com.codahale.metrics.annotation.Timed;
-import de.otto.teamdojo.service.CommentQueryService;
 import de.otto.teamdojo.service.CommentService;
-import de.otto.teamdojo.service.dto.CommentCriteria;
-import de.otto.teamdojo.service.dto.CommentDTO;
 import de.otto.teamdojo.web.rest.errors.BadRequestAlertException;
 import de.otto.teamdojo.web.rest.util.HeaderUtil;
+import de.otto.teamdojo.web.rest.util.PaginationUtil;
+import de.otto.teamdojo.service.dto.CommentDTO;
+import de.otto.teamdojo.service.dto.CommentCriteria;
+import de.otto.teamdojo.service.CommentQueryService;
 import io.github.jhipster.web.util.ResponseUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 import java.net.URI;
 import java.net.URISyntaxException;
+
 import java.util.List;
 import java.util.Optional;
 
@@ -84,15 +90,17 @@ public class CommentResource {
     /**
      * GET  /comments : get all the comments.
      *
+     * @param pageable the pagination information
      * @param criteria the criterias which the requested entities should match
      * @return the ResponseEntity with status 200 (OK) and the list of comments in body
      */
     @GetMapping("/comments")
     @Timed
-    public ResponseEntity<List<CommentDTO>> getAllComments(CommentCriteria criteria) {
+    public ResponseEntity<List<CommentDTO>> getAllComments(CommentCriteria criteria, Pageable pageable) {
         log.debug("REST request to get Comments by criteria: {}", criteria);
-        List<CommentDTO> entityList = commentQueryService.findByCriteria(criteria);
-        return ResponseEntity.ok().body(entityList);
+        Page<CommentDTO> page = commentQueryService.findByCriteria(criteria, pageable);
+        HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(page, "/api/comments");
+        return new ResponseEntity<>(page.getContent(), headers, HttpStatus.OK);
     }
 
     /**

--- a/src/main/webapp/app/entities/comment/comment.component.html
+++ b/src/main/webapp/app/entities/comment/comment.component.html
@@ -13,16 +13,21 @@
     <div class="table-responsive" *ngIf="comments">
         <table class="table table-striped">
             <thead>
-            <tr>
-            <th><span jhiTranslate="global.field.id">ID</span></th>
-            <th><span jhiTranslate="teamdojoApp.comment.text">Text</span></th>
-            <th><span jhiTranslate="teamdojoApp.comment.creationDate">Creation Date</span></th>
-            <th><span jhiTranslate="teamdojoApp.comment.team">Team</span></th>
-            <th><span jhiTranslate="teamdojoApp.comment.skill">Skill</span></th>
+            <tr jhiSort [(predicate)]="predicate" [(ascending)]="reverse" [callback]="reset.bind(this)">
+                <th jhiSortBy="id"><span jhiTranslate="global.field.id">ID</span> <span class="fa fa-sort"></span></th>
+                <th jhiSortBy="text"><span jhiTranslate="teamdojoApp.comment.text">Text</span> <span
+                    class="fa fa-sort"></span></th>
+                <th jhiSortBy="creationDate"><span jhiTranslate="teamdojoApp.comment.creationDate">Creation Date</span>
+                    <span class="fa fa-sort"></span></th>
+                <th jhiSortBy="teamShortName"><span jhiTranslate="teamdojoApp.comment.team">Team</span> <span
+                    class="fa fa-sort"></span></th>
+                <th jhiSortBy="skillTitle"><span jhiTranslate="teamdojoApp.comment.skill">Skill</span> <span
+                    class="fa fa-sort"></span></th>
             <th></th>
             </tr>
             </thead>
-            <tbody>
+            <tbody infinite-scroll (scrolled)="loadPage(page + 1)" [infiniteScrollDisabled]="page >= links['last']"
+                   [infiniteScrollDistance]="0">
             <tr *ngFor="let comment of comments ;trackBy: trackId">
                 <td><a [routerLink]="['/comment', comment.id, 'view' ]">{{comment.id}}</a></td>
                 <td>{{comment.text}}</td>

--- a/src/main/webapp/app/entities/comment/comment.component.ts
+++ b/src/main/webapp/app/entities/comment/comment.component.ts
@@ -1,10 +1,12 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
-import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
+import { HttpErrorResponse, HttpHeaders, HttpResponse } from '@angular/common/http';
 import { Subscription } from 'rxjs/Subscription';
-import { JhiEventManager, JhiAlertService } from 'ng-jhipster';
+import { JhiEventManager, JhiParseLinks, JhiAlertService } from 'ng-jhipster';
 
 import { IComment } from 'app/shared/model/comment.model';
 import { Principal } from 'app/core';
+
+import { ITEMS_PER_PAGE } from 'app/shared';
 import { CommentService } from './comment.service';
 
 @Component({
@@ -15,21 +17,53 @@ export class CommentComponent implements OnInit, OnDestroy {
     comments: IComment[];
     currentAccount: any;
     eventSubscriber: Subscription;
+    itemsPerPage: number;
+    links: any;
+    page: any;
+    predicate: any;
+    queryCount: any;
+    reverse: any;
+    totalItems: number;
 
     constructor(
         private commentService: CommentService,
         private jhiAlertService: JhiAlertService,
         private eventManager: JhiEventManager,
+        private parseLinks: JhiParseLinks,
         private principal: Principal
-    ) {}
+    ) {
+        this.comments = [];
+        this.itemsPerPage = ITEMS_PER_PAGE;
+        this.page = 0;
+        this.links = {
+            last: 0
+        };
+        this.predicate = 'id';
+        this.reverse = true;
+    }
 
     loadAll() {
-        this.commentService.query().subscribe(
-            (res: HttpResponse<IComment[]>) => {
-                this.comments = res.body;
-            },
-            (res: HttpErrorResponse) => this.onError(res.message)
-        );
+        this.commentService
+            .query({
+                page: this.page,
+                size: this.itemsPerPage,
+                sort: this.sort()
+            })
+            .subscribe(
+                (res: HttpResponse<IComment[]>) => this.paginateComments(res.body, res.headers),
+                (res: HttpErrorResponse) => this.onError(res.message)
+            );
+    }
+
+    reset() {
+        this.page = 0;
+        this.comments = [];
+        this.loadAll();
+    }
+
+    loadPage(page) {
+        this.page = page;
+        this.loadAll();
     }
 
     ngOnInit() {
@@ -49,7 +83,23 @@ export class CommentComponent implements OnInit, OnDestroy {
     }
 
     registerChangeInComments() {
-        this.eventSubscriber = this.eventManager.subscribe('commentListModification', response => this.loadAll());
+        this.eventSubscriber = this.eventManager.subscribe('commentListModification', response => this.reset());
+    }
+
+    sort() {
+        const result = [this.predicate + ',' + (this.reverse ? 'asc' : 'desc')];
+        if (this.predicate !== 'id') {
+            result.push('id');
+        }
+        return result;
+    }
+
+    private paginateComments(data: IComment[], headers: HttpHeaders) {
+        this.links = this.parseLinks.parse(headers.get('link'));
+        this.totalItems = parseInt(headers.get('X-Total-Count'), 10);
+        for (let i = 0; i < data.length; i++) {
+            this.comments.push(data[i]);
+        }
     }
 
     private onError(errorMessage: string) {


### PR DESCRIPTION
Second PR of a series of several pull requests for the EDO-162 ticket.
To simplify the review only one single entity is regenerated for each request in this series - in this case, the comment entity.