### PR TITLE
[EDO-162] make level skill list sortable in admin view

### DIFF
--- a/.jhipster/LevelSkill.json
+++ b/.jhipster/LevelSkill.json
@@ -27,5 +27,5 @@
     "service": "serviceImpl",
     "entityTableName": "level_skill",
     "jpaMetamodelFiltering": true,
-    "pagination": "no"
+    "pagination": "infinite-scroll"
 }

--- a/src/main/java/de/otto/teamdojo/service/LevelSkillQueryService.java
+++ b/src/main/java/de/otto/teamdojo/service/LevelSkillQueryService.java
@@ -1,14 +1,7 @@
 package de.otto.teamdojo.service;
 
-import de.otto.teamdojo.domain.LevelSkill;
-import de.otto.teamdojo.domain.LevelSkill_;
-import de.otto.teamdojo.domain.Level_;
-import de.otto.teamdojo.domain.Skill_;
-import de.otto.teamdojo.repository.LevelSkillRepository;
-import de.otto.teamdojo.service.dto.LevelSkillCriteria;
-import de.otto.teamdojo.service.dto.LevelSkillDTO;
-import de.otto.teamdojo.service.mapper.LevelSkillMapper;
-import io.github.jhipster.service.QueryService;
+import java.util.List;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Page;
@@ -17,7 +10,15 @@ import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
+import io.github.jhipster.service.QueryService;
+
+import de.otto.teamdojo.domain.LevelSkill;
+import de.otto.teamdojo.domain.*; // for static metamodels
+import de.otto.teamdojo.repository.LevelSkillRepository;
+import de.otto.teamdojo.service.dto.LevelSkillCriteria;
+
+import de.otto.teamdojo.service.dto.LevelSkillDTO;
+import de.otto.teamdojo.service.mapper.LevelSkillMapper;
 
 /**
  * Service for executing complex queries for LevelSkill entities in the database.
@@ -42,7 +43,6 @@ public class LevelSkillQueryService extends QueryService<LevelSkill> {
 
     /**
      * Return a {@link List} of {@link LevelSkillDTO} which matches the criteria from the database
-     *
      * @param criteria The object which holds all the filters, which the entities should match.
      * @return the matching entities.
      */
@@ -55,9 +55,8 @@ public class LevelSkillQueryService extends QueryService<LevelSkill> {
 
     /**
      * Return a {@link Page} of {@link LevelSkillDTO} which matches the criteria from the database
-     *
      * @param criteria The object which holds all the filters, which the entities should match.
-     * @param page     The page, which should be returned.
+     * @param page The page, which should be returned.
      * @return the matching entities.
      */
     @Transactional(readOnly = true)

--- a/src/main/java/de/otto/teamdojo/service/LevelSkillService.java
+++ b/src/main/java/de/otto/teamdojo/service/LevelSkillService.java
@@ -1,10 +1,10 @@
 package de.otto.teamdojo.service;
 
 import de.otto.teamdojo.service.dto.LevelSkillDTO;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
-import java.util.List;
 import java.util.Optional;
 
 /**
@@ -23,9 +23,10 @@ public interface LevelSkillService {
     /**
      * Get all the levelSkills.
      *
+     * @param pageable the pagination information
      * @return the list of entities
      */
-    List<LevelSkillDTO> findAll();
+    Page<LevelSkillDTO> findAll(Pageable pageable);
 
 
     /**
@@ -45,6 +46,4 @@ public interface LevelSkillService {
      * @param id the id of the entity
      */
     void delete(Long id);
-
-
 }

--- a/src/main/java/de/otto/teamdojo/service/LevelSkillService.java
+++ b/src/main/java/de/otto/teamdojo/service/LevelSkillService.java
@@ -5,6 +5,7 @@ import de.otto.teamdojo.service.dto.LevelSkillDTO;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
 import java.util.Optional;
 
 /**

--- a/src/main/java/de/otto/teamdojo/service/impl/LevelSkillServiceImpl.java
+++ b/src/main/java/de/otto/teamdojo/service/impl/LevelSkillServiceImpl.java
@@ -1,21 +1,19 @@
 package de.otto.teamdojo.service.impl;
 
+import de.otto.teamdojo.service.LevelSkillService;
 import de.otto.teamdojo.domain.LevelSkill;
 import de.otto.teamdojo.repository.LevelSkillRepository;
-import de.otto.teamdojo.service.LevelSkillService;
 import de.otto.teamdojo.service.dto.LevelSkillDTO;
 import de.otto.teamdojo.service.mapper.LevelSkillMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.LinkedList;
-import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * Service Implementation for managing LevelSkill.
@@ -52,15 +50,15 @@ public class LevelSkillServiceImpl implements LevelSkillService {
     /**
      * Get all the levelSkills.
      *
+     * @param pageable the pagination information
      * @return the list of entities
      */
     @Override
     @Transactional(readOnly = true)
-    public List<LevelSkillDTO> findAll() {
+    public Page<LevelSkillDTO> findAll(Pageable pageable) {
         log.debug("Request to get all LevelSkills");
-        return levelSkillRepository.findAll().stream()
-            .map(levelSkillMapper::toDto)
-            .collect(Collectors.toCollection(LinkedList::new));
+        return levelSkillRepository.findAll(pageable)
+            .map(levelSkillMapper::toDto);
     }
 
 

--- a/src/main/java/de/otto/teamdojo/service/impl/LevelSkillServiceImpl.java
+++ b/src/main/java/de/otto/teamdojo/service/impl/LevelSkillServiceImpl.java
@@ -1,19 +1,21 @@
 package de.otto.teamdojo.service.impl;
 
-import de.otto.teamdojo.service.LevelSkillService;
 import de.otto.teamdojo.domain.LevelSkill;
 import de.otto.teamdojo.repository.LevelSkillRepository;
+import de.otto.teamdojo.service.LevelSkillService;
 import de.otto.teamdojo.service.dto.LevelSkillDTO;
 import de.otto.teamdojo.service.mapper.LevelSkillMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * Service Implementation for managing LevelSkill.

--- a/src/main/java/de/otto/teamdojo/web/rest/LevelSkillResource.java
+++ b/src/main/java/de/otto/teamdojo/web/rest/LevelSkillResource.java
@@ -1,21 +1,27 @@
 package de.otto.teamdojo.web.rest;
 
 import com.codahale.metrics.annotation.Timed;
-import de.otto.teamdojo.service.LevelSkillQueryService;
 import de.otto.teamdojo.service.LevelSkillService;
-import de.otto.teamdojo.service.dto.LevelSkillCriteria;
-import de.otto.teamdojo.service.dto.LevelSkillDTO;
 import de.otto.teamdojo.web.rest.errors.BadRequestAlertException;
 import de.otto.teamdojo.web.rest.util.HeaderUtil;
+import de.otto.teamdojo.web.rest.util.PaginationUtil;
+import de.otto.teamdojo.service.dto.LevelSkillDTO;
+import de.otto.teamdojo.service.dto.LevelSkillCriteria;
+import de.otto.teamdojo.service.LevelSkillQueryService;
 import io.github.jhipster.web.util.ResponseUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 import java.net.URI;
 import java.net.URISyntaxException;
+
 import java.util.List;
 import java.util.Optional;
 
@@ -84,15 +90,17 @@ public class LevelSkillResource {
     /**
      * GET  /level-skills : get all the levelSkills.
      *
+     * @param pageable the pagination information
      * @param criteria the criterias which the requested entities should match
      * @return the ResponseEntity with status 200 (OK) and the list of levelSkills in body
      */
     @GetMapping("/level-skills")
     @Timed
-    public ResponseEntity<List<LevelSkillDTO>> getAllLevelSkills(LevelSkillCriteria criteria) {
+    public ResponseEntity<List<LevelSkillDTO>> getAllLevelSkills(LevelSkillCriteria criteria, Pageable pageable) {
         log.debug("REST request to get LevelSkills by criteria: {}", criteria);
-        List<LevelSkillDTO> entityList = levelSkillQueryService.findByCriteria(criteria);
-        return ResponseEntity.ok().body(entityList);
+        Page<LevelSkillDTO> page = levelSkillQueryService.findByCriteria(criteria, pageable);
+        HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(page, "/api/level-skills");
+        return new ResponseEntity<>(page.getContent(), headers, HttpStatus.OK);
     }
 
     /**

--- a/src/main/webapp/app/entities/level-skill/level-skill.component.html
+++ b/src/main/webapp/app/entities/level-skill/level-skill.component.html
@@ -13,14 +13,17 @@
     <div class="table-responsive" *ngIf="levelSkills">
         <table class="table table-striped">
             <thead>
-            <tr>
-            <th><span jhiTranslate="global.field.id">ID</span></th>
-            <th><span jhiTranslate="teamdojoApp.levelSkill.skill">Skill</span></th>
-            <th><span jhiTranslate="teamdojoApp.levelSkill.level">Level</span></th>
+            <tr jhiSort [(predicate)]="predicate" [(ascending)]="reverse" [callback]="reset.bind(this)">
+                <th jhiSortBy="id"><span jhiTranslate="global.field.id">ID</span> <span class="fa fa-sort"></span></th>
+                <th jhiSortBy="skillTitle"><span jhiTranslate="teamdojoApp.levelSkill.skill">Skill</span> <span
+                    class="fa fa-sort"></span></th>
+                <th jhiSortBy="levelName"><span jhiTranslate="teamdojoApp.levelSkill.level">Level</span> <span
+                    class="fa fa-sort"></span></th>
             <th></th>
             </tr>
             </thead>
-            <tbody>
+            <tbody infinite-scroll (scrolled)="loadPage(page + 1)" [infiniteScrollDisabled]="page >= links['last']"
+                   [infiniteScrollDistance]="0">
             <tr *ngFor="let levelSkill of levelSkills ;trackBy: trackId">
                 <td><a [routerLink]="['/level-skill', levelSkill.id, 'view' ]">{{levelSkill.id}}</a></td>
                 <td>

--- a/src/main/webapp/app/entities/level-skill/level-skill.component.ts
+++ b/src/main/webapp/app/entities/level-skill/level-skill.component.ts
@@ -1,10 +1,12 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
-import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
+import { HttpErrorResponse, HttpHeaders, HttpResponse } from '@angular/common/http';
 import { Subscription } from 'rxjs/Subscription';
-import { JhiEventManager, JhiAlertService } from 'ng-jhipster';
+import { JhiEventManager, JhiParseLinks, JhiAlertService } from 'ng-jhipster';
 
 import { ILevelSkill } from 'app/shared/model/level-skill.model';
 import { Principal } from 'app/core';
+
+import { ITEMS_PER_PAGE } from 'app/shared';
 import { LevelSkillService } from './level-skill.service';
 
 @Component({
@@ -15,21 +17,53 @@ export class LevelSkillComponent implements OnInit, OnDestroy {
     levelSkills: ILevelSkill[];
     currentAccount: any;
     eventSubscriber: Subscription;
+    itemsPerPage: number;
+    links: any;
+    page: any;
+    predicate: any;
+    queryCount: any;
+    reverse: any;
+    totalItems: number;
 
     constructor(
         private levelSkillService: LevelSkillService,
         private jhiAlertService: JhiAlertService,
         private eventManager: JhiEventManager,
+        private parseLinks: JhiParseLinks,
         private principal: Principal
-    ) {}
+    ) {
+        this.levelSkills = [];
+        this.itemsPerPage = ITEMS_PER_PAGE;
+        this.page = 0;
+        this.links = {
+            last: 0
+        };
+        this.predicate = 'id';
+        this.reverse = true;
+    }
 
     loadAll() {
-        this.levelSkillService.query().subscribe(
-            (res: HttpResponse<ILevelSkill[]>) => {
-                this.levelSkills = res.body;
-            },
-            (res: HttpErrorResponse) => this.onError(res.message)
-        );
+        this.levelSkillService
+            .query({
+                page: this.page,
+                size: this.itemsPerPage,
+                sort: this.sort()
+            })
+            .subscribe(
+                (res: HttpResponse<ILevelSkill[]>) => this.paginateLevelSkills(res.body, res.headers),
+                (res: HttpErrorResponse) => this.onError(res.message)
+            );
+    }
+
+    reset() {
+        this.page = 0;
+        this.levelSkills = [];
+        this.loadAll();
+    }
+
+    loadPage(page) {
+        this.page = page;
+        this.loadAll();
     }
 
     ngOnInit() {
@@ -49,7 +83,23 @@ export class LevelSkillComponent implements OnInit, OnDestroy {
     }
 
     registerChangeInLevelSkills() {
-        this.eventSubscriber = this.eventManager.subscribe('levelSkillListModification', response => this.loadAll());
+        this.eventSubscriber = this.eventManager.subscribe('levelSkillListModification', response => this.reset());
+    }
+
+    sort() {
+        const result = [this.predicate + ',' + (this.reverse ? 'asc' : 'desc')];
+        if (this.predicate !== 'id') {
+            result.push('id');
+        }
+        return result;
+    }
+
+    private paginateLevelSkills(data: ILevelSkill[], headers: HttpHeaders) {
+        this.links = this.parseLinks.parse(headers.get('link'));
+        this.totalItems = parseInt(headers.get('X-Total-Count'), 10);
+        for (let i = 0; i < data.length; i++) {
+            this.levelSkills.push(data[i]);
+        }
     }
 
     private onError(errorMessage: string) {


### PR DESCRIPTION
Fourth PR of a series of several pull requests for the EDO-162 ticket.
To simplify the review only one single entity is regenerated for each request in this series - in this case, the level skill entity.