### PR TITLE
[EDO-162] Fix Level GET endpoint to be compatible with new admin frontend

### DIFF
--- a/src/main/java/de/otto/teamdojo/web/rest/LevelResource.java
+++ b/src/main/java/de/otto/teamdojo/web/rest/LevelResource.java
@@ -106,8 +106,9 @@ public class LevelResource {
         if(criteria != null && criteria.getSkillsId() != null && criteria.getSkillsId().getIn() != null)
             return getAllLevelsBySkills(criteria.getSkillsId().getIn(), pageable);
 
-        List<LevelDTO> entityList = levelQueryService.findByCriteria(criteria);
-        return ResponseEntity.ok().body(entityList);
+        Page<LevelDTO> page = levelQueryService.findByCriteria(criteria, pageable);
+        HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(page, "/api/levels");
+        return new ResponseEntity<>(page.getContent(), headers, HttpStatus.OK);
     }
 
 


### PR DESCRIPTION
I've just re-review the pull request #20 and the admin view for Level is not compatible with the backend endpoint.
All these changes are fine. But `LevelResource.java` must also be changed, in order for the frontend to work. The endpoint `GET /api/levels` must response with pagination headers applied.