### PR TITLE
[EDO-161] Filter for Entities in Administration

### DIFF
--- a/src/main/webapp/app/entities/level-skill/level-skill.component.html
+++ b/src/main/webapp/app/entities/level-skill/level-skill.component.html
@@ -21,6 +21,11 @@
                     class="fa fa-sort"></span></th>
             <th></th>
             </tr>
+
+            <tr jhi-table-filter [fields]="[
+                {name: 'id', filter: true, operator: 'in'}
+            ]" (onFilterChanged)="applyFilter($event)"></tr>
+
             </thead>
             <tbody infinite-scroll (scrolled)="loadPage(page + 1)" [infiniteScrollDisabled]="page >= links['last']"
                    [infiniteScrollDistance]="0">

--- a/src/main/webapp/app/entities/level-skill/level-skill.component.html
+++ b/src/main/webapp/app/entities/level-skill/level-skill.component.html
@@ -23,13 +23,15 @@
             </tr>
 
             <tr jhi-table-filter [fields]="[
-                {name: 'id', filter: true, operator: 'in'}
+                {name: 'id', filter: true, operator: 'equals'},
+                {name: 'skillTitle', filter: true, operator: 'contains'},
+                {name: 'levelName', filter: true, operator: 'contains'}
             ]" (onFilterChanged)="applyFilter($event)"></tr>
 
             </thead>
             <tbody infinite-scroll (scrolled)="loadPage(page + 1)" [infiniteScrollDisabled]="page >= links['last']"
                    [infiniteScrollDistance]="0">
-            <tr *ngFor="let levelSkill of levelSkills ;trackBy: trackId">
+            <tr *ngFor="let levelSkill of filteredLevelSkills ;trackBy: trackId">
                 <td><a [routerLink]="['/level-skill', levelSkill.id, 'view' ]">{{levelSkill.id}}</a></td>
                 <td>
                     <div *ngIf="levelSkill.skillId">

--- a/src/main/webapp/app/entities/level-skill/level-skill.component.ts
+++ b/src/main/webapp/app/entities/level-skill/level-skill.component.ts
@@ -115,6 +115,6 @@ export class LevelSkillComponent implements OnInit, OnDestroy {
     }
 
     private onError(errorMessage: string) {
-        this.jhiAlertService.error(errorMessage, null, null);
+        console.error(errorMessage);
     }
 }

--- a/src/main/webapp/app/entities/level-skill/level-skill.component.ts
+++ b/src/main/webapp/app/entities/level-skill/level-skill.component.ts
@@ -8,6 +8,7 @@ import { Principal } from 'app/core';
 
 import { ITEMS_PER_PAGE } from 'app/shared';
 import { LevelSkillService } from './level-skill.service';
+import { FilterQuery } from 'app/shared/table-filter/table-filter.component';
 
 @Component({
     selector: 'jhi-level-skill',
@@ -24,6 +25,8 @@ export class LevelSkillComponent implements OnInit, OnDestroy {
     queryCount: any;
     reverse: any;
     totalItems: number;
+
+    private filters: FilterQuery[] = [];
 
     constructor(
         private levelSkillService: LevelSkillService,
@@ -43,8 +46,12 @@ export class LevelSkillComponent implements OnInit, OnDestroy {
     }
 
     loadAll() {
+        const query = {};
+        this.filters.forEach(filter => (query[`${filter.fieldName}.${filter.operator}`] = filter.query));
+
         this.levelSkillService
             .query({
+                ...query,
                 page: this.page,
                 size: this.itemsPerPage,
                 sort: this.sort()
@@ -53,6 +60,11 @@ export class LevelSkillComponent implements OnInit, OnDestroy {
                 (res: HttpResponse<ILevelSkill[]>) => this.paginateLevelSkills(res.body, res.headers),
                 (res: HttpErrorResponse) => this.onError(res.message)
             );
+    }
+
+    applyFilter(query: FilterQuery[]) {
+        this.filters = query;
+        this.reset();
     }
 
     reset() {

--- a/src/main/webapp/app/entities/skill/skill.component.html
+++ b/src/main/webapp/app/entities/skill/skill.component.html
@@ -28,7 +28,7 @@
             </tr>
 
             <tr jhi-table-filter [fields]="[
-                {name: 'id', filter: true, operator: 'in'},
+                {name: 'id', filter: true, operator: 'equals'},
                 {name: 'title', filter: true},
                 {name: 'description', filter: true},
                 {name: 'implementation', filter: true},

--- a/src/main/webapp/app/entities/skill/skill.component.html
+++ b/src/main/webapp/app/entities/skill/skill.component.html
@@ -28,7 +28,7 @@
             </tr>
 
             <tr jhi-table-filter [fields]="[
-                {name: 'id', filter: false},
+                {name: 'id', filter: true, operator: 'in'},
                 {name: 'title', filter: true},
                 {name: 'description', filter: true},
                 {name: 'implementation', filter: true},

--- a/src/main/webapp/app/entities/skill/skill.component.html
+++ b/src/main/webapp/app/entities/skill/skill.component.html
@@ -26,6 +26,20 @@
             <th jhiSortBy="rateCount"><span jhiTranslate="teamdojoApp.skill.rateCount">Rate Count</span> <span class="fa fa-sort"></span></th>
             <th></th>
             </tr>
+
+            <tr jhi-table-filter [fields]="[
+                {name: 'id', filter: false},
+                {name: 'title', filter: true},
+                {name: 'description', filter: true},
+                {name: 'implementation', filter: true},
+                {name: 'validation', filter: true},
+                {name: 'expiryPeriod', filter: false},
+                {name: 'contact', filter: true},
+                {name: 'score', filter: false},
+                {name: 'rateScore', filter: false},
+                {name: 'rateCount', filter: false}
+            ]" (onFilterChanged)="applyFilter($event)"></tr>
+
             </thead>
             <tbody infinite-scroll (scrolled)="loadPage(page + 1)" [infiniteScrollDisabled]="page >= links['last']" [infiniteScrollDistance]="0">
             <tr *ngFor="let skill of skills ;trackBy: trackId">

--- a/src/main/webapp/app/entities/skill/skill.component.html
+++ b/src/main/webapp/app/entities/skill/skill.component.html
@@ -34,7 +34,7 @@
                 {name: 'implementation', filter: true},
                 {name: 'validation', filter: true},
                 {name: 'expiryPeriod', filter: false},
-                {name: 'contact', filter: true},
+                {name: 'contact', filter: false},
                 {name: 'score', filter: false},
                 {name: 'rateScore', filter: false},
                 {name: 'rateCount', filter: false}

--- a/src/main/webapp/app/entities/skill/skill.component.ts
+++ b/src/main/webapp/app/entities/skill/skill.component.ts
@@ -8,6 +8,7 @@ import { Principal } from 'app/core';
 
 import { ITEMS_PER_PAGE } from 'app/shared';
 import { SkillService } from './skill.service';
+import { FilterQuery } from 'app/shared/table-filter/table-filter.component';
 
 @Component({
     selector: 'jhi-skill',
@@ -24,6 +25,8 @@ export class SkillComponent implements OnInit, OnDestroy {
     queryCount: any;
     reverse: any;
     totalItems: number;
+
+    private filters: FilterQuery[] = [];
 
     constructor(
         private skillService: SkillService,
@@ -43,8 +46,12 @@ export class SkillComponent implements OnInit, OnDestroy {
     }
 
     loadAll() {
+        const query = {};
+        this.filters.forEach(filter => (query[`${filter.fieldName}.contains`] = filter.query));
+
         this.skillService
             .query({
+                ...query,
                 page: this.page,
                 size: this.itemsPerPage,
                 sort: this.sort()
@@ -53,6 +60,11 @@ export class SkillComponent implements OnInit, OnDestroy {
                 (res: HttpResponse<ISkill[]>) => this.paginateSkills(res.body, res.headers),
                 (res: HttpErrorResponse) => this.onError(res.message)
             );
+    }
+
+    applyFilter(query: FilterQuery[]) {
+        this.filters = query;
+        this.reset();
     }
 
     reset() {

--- a/src/main/webapp/app/entities/skill/skill.component.ts
+++ b/src/main/webapp/app/entities/skill/skill.component.ts
@@ -47,7 +47,7 @@ export class SkillComponent implements OnInit, OnDestroy {
 
     loadAll() {
         const query = {};
-        this.filters.forEach(filter => (query[`${filter.fieldName}.contains`] = filter.query));
+        this.filters.forEach(filter => (query[`${filter.fieldName}.${filter.operator}`] = filter.query));
 
         this.skillService
             .query({

--- a/src/main/webapp/app/entities/skill/skill.component.ts
+++ b/src/main/webapp/app/entities/skill/skill.component.ts
@@ -115,6 +115,6 @@ export class SkillComponent implements OnInit, OnDestroy {
     }
 
     private onError(errorMessage: string) {
-        this.jhiAlertService.error(errorMessage, null, null);
+        console.error(errorMessage);
     }
 }

--- a/src/main/webapp/app/entities/skill/skill.module.ts
+++ b/src/main/webapp/app/entities/skill/skill.module.ts
@@ -14,20 +14,11 @@ import {
     SkillResolve
 } from './';
 
-import { TableFilterComponent } from 'app/shared/table-filter/table-filter.component';
-
 const ENTITY_STATES = [...skillRoute, ...skillPopupRoute];
 
 @NgModule({
     imports: [TeamdojoSharedModule, RouterModule.forChild(ENTITY_STATES)],
-    declarations: [
-        SkillComponent,
-        SkillDetailComponent,
-        SkillUpdateComponent,
-        SkillDeleteDialogComponent,
-        SkillDeletePopupComponent,
-        TableFilterComponent
-    ],
+    declarations: [SkillComponent, SkillDetailComponent, SkillUpdateComponent, SkillDeleteDialogComponent, SkillDeletePopupComponent],
     entryComponents: [SkillComponent, SkillUpdateComponent, SkillDeleteDialogComponent, SkillDeletePopupComponent],
     providers: [SkillService, SkillResolve],
     schemas: [CUSTOM_ELEMENTS_SCHEMA]

--- a/src/main/webapp/app/entities/skill/skill.module.ts
+++ b/src/main/webapp/app/entities/skill/skill.module.ts
@@ -14,11 +14,20 @@ import {
     SkillResolve
 } from './';
 
+import { TableFilterComponent } from 'app/shared/table-filter/table-filter.component';
+
 const ENTITY_STATES = [...skillRoute, ...skillPopupRoute];
 
 @NgModule({
     imports: [TeamdojoSharedModule, RouterModule.forChild(ENTITY_STATES)],
-    declarations: [SkillComponent, SkillDetailComponent, SkillUpdateComponent, SkillDeleteDialogComponent, SkillDeletePopupComponent],
+    declarations: [
+        SkillComponent,
+        SkillDetailComponent,
+        SkillUpdateComponent,
+        SkillDeleteDialogComponent,
+        SkillDeletePopupComponent,
+        TableFilterComponent
+    ],
     entryComponents: [SkillComponent, SkillUpdateComponent, SkillDeleteDialogComponent, SkillDeletePopupComponent],
     providers: [SkillService, SkillResolve],
     schemas: [CUSTOM_ELEMENTS_SCHEMA]

--- a/src/main/webapp/app/shared/shared.module.ts
+++ b/src/main/webapp/app/shared/shared.module.ts
@@ -5,13 +5,21 @@ import { NgbDateMomentAdapter } from './util/datepicker-adapter';
 import { HasAnyAuthorityDirective, JhiLoginModalComponent, TeamdojoSharedCommonModule, TeamdojoSharedLibsModule } from './';
 import { BackgroundComponent } from 'app/shared/background/background.component';
 import { TeamsStatusComponent } from 'app/teams/teams-status.component';
+import { TableFilterComponent } from 'app/shared/table-filter/table-filter.component';
 
 @NgModule({
     imports: [TeamdojoSharedLibsModule, TeamdojoSharedCommonModule],
-    declarations: [JhiLoginModalComponent, HasAnyAuthorityDirective, BackgroundComponent, TeamsStatusComponent],
+    declarations: [JhiLoginModalComponent, HasAnyAuthorityDirective, BackgroundComponent, TeamsStatusComponent, TableFilterComponent],
     providers: [{ provide: NgbDateAdapter, useClass: NgbDateMomentAdapter }],
     entryComponents: [JhiLoginModalComponent],
-    exports: [TeamdojoSharedCommonModule, JhiLoginModalComponent, HasAnyAuthorityDirective, BackgroundComponent, TeamsStatusComponent],
+    exports: [
+        TeamdojoSharedCommonModule,
+        JhiLoginModalComponent,
+        HasAnyAuthorityDirective,
+        BackgroundComponent,
+        TeamsStatusComponent,
+        TableFilterComponent
+    ],
     schemas: [CUSTOM_ELEMENTS_SCHEMA]
 })
 export class TeamdojoSharedModule {}

--- a/src/main/webapp/app/shared/table-filter/table-filter.component.html
+++ b/src/main/webapp/app/shared/table-filter/table-filter.component.html
@@ -1,0 +1,3 @@
+<th *ngFor="let field of fields">
+    <input *ngIf="field.filter" type="text" class="form-control" [(ngModel)]="filterInputs[field.name]" (ngModelChange)="updateFilter()">
+</th>

--- a/src/main/webapp/app/shared/table-filter/table-filter.component.html
+++ b/src/main/webapp/app/shared/table-filter/table-filter.component.html
@@ -1,3 +1,6 @@
 <th *ngFor="let field of fields">
-    <input *ngIf="field.filter" type="text" class="form-control" [(ngModel)]="filterInputs[field.name]" (ngModelChange)="updateFilter()">
+    <div *ngIf="field.filter" class="filter-field">
+        <input type="text" class="form-control" [(ngModel)]="filterInputs[field.name]" (ngModelChange)="updateFilter()">
+        <span class="filter-icon fa fa-search"></span>
+    </div>
 </th>

--- a/src/main/webapp/app/shared/table-filter/table-filter.component.ts
+++ b/src/main/webapp/app/shared/table-filter/table-filter.component.ts
@@ -1,4 +1,5 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { Subject } from 'rxjs';
 
 export interface TableField {
     name: string;
@@ -20,12 +21,18 @@ export class TableFilterComponent {
 
     @Output() onFilterChanged = new EventEmitter<FilterQuery[]>();
 
+    filterChanged: Subject<FilterQuery[]> = new Subject();
+
     private filterInputs: { [k: string]: string } = {};
+
+    constructor() {
+        this.filterChanged.debounceTime(500).subscribe(query => this.onFilterChanged.emit(query));
+    }
 
     updateFilter() {
         const query: FilterQuery[] = Object.keys(this.filterInputs)
             .filter(field => this.filterInputs[field] && this.filterInputs[field] !== '')
             .map(field => <FilterQuery>{ fieldName: field, query: this.filterInputs[field] });
-        this.onFilterChanged.emit(query);
+        this.filterChanged.next(query);
     }
 }

--- a/src/main/webapp/app/shared/table-filter/table-filter.component.ts
+++ b/src/main/webapp/app/shared/table-filter/table-filter.component.ts
@@ -12,7 +12,8 @@ export interface FilterQuery {
 
 @Component({
     selector: 'tr[jhi-table-filter]',
-    templateUrl: './table-filter.component.html'
+    templateUrl: './table-filter.component.html',
+    styleUrls: ['./table-filter.scss']
 })
 export class TableFilterComponent {
     @Input() fields: TableField[];

--- a/src/main/webapp/app/shared/table-filter/table-filter.component.ts
+++ b/src/main/webapp/app/shared/table-filter/table-filter.component.ts
@@ -1,0 +1,30 @@
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+
+export interface TableField {
+    name: string;
+    filter: boolean;
+}
+
+export interface FilterQuery {
+    fieldName: string;
+    query: string;
+}
+
+@Component({
+    selector: 'tr[jhi-table-filter]',
+    templateUrl: './table-filter.component.html'
+})
+export class TableFilterComponent {
+    @Input() fields: TableField[];
+
+    @Output() onFilterChanged = new EventEmitter<FilterQuery[]>();
+
+    private filterInputs: { [k: string]: string } = {};
+
+    updateFilter() {
+        const query: FilterQuery[] = Object.keys(this.filterInputs)
+            .filter(field => this.filterInputs[field] && this.filterInputs[field] !== '')
+            .map(field => <FilterQuery>{ fieldName: field, query: this.filterInputs[field] });
+        this.onFilterChanged.emit(query);
+    }
+}

--- a/src/main/webapp/app/shared/table-filter/table-filter.component.ts
+++ b/src/main/webapp/app/shared/table-filter/table-filter.component.ts
@@ -4,11 +4,13 @@ import { Subject } from 'rxjs';
 export interface TableField {
     name: string;
     filter: boolean;
+    operator?: string;
 }
 
 export interface FilterQuery {
     fieldName: string;
     query: string;
+    operator: string;
 }
 
 @Component({
@@ -16,7 +18,7 @@ export interface FilterQuery {
     templateUrl: './table-filter.component.html',
     styleUrls: ['./table-filter.scss']
 })
-export class TableFilterComponent {
+export class TableFilterComponent implements OnInit {
     @Input() fields: TableField[];
 
     @Output() onFilterChanged = new EventEmitter<FilterQuery[]>();
@@ -25,14 +27,29 @@ export class TableFilterComponent {
 
     private filterInputs: { [k: string]: string } = {};
 
+    private filterOperators: { [k: string]: string } = {};
+
     constructor() {
         this.filterChanged.debounceTime(500).subscribe(query => this.onFilterChanged.emit(query));
+    }
+
+    ngOnInit(): void {
+        this.fields.forEach(f => {
+            this.filterOperators[f.name] = f.operator;
+        });
     }
 
     updateFilter() {
         const query: FilterQuery[] = Object.keys(this.filterInputs)
             .filter(field => this.filterInputs[field] && this.filterInputs[field] !== '')
-            .map(field => <FilterQuery>{ fieldName: field, query: this.filterInputs[field] });
+            .map(
+                field =>
+                    <FilterQuery>{
+                        fieldName: field,
+                        query: this.filterInputs[field],
+                        operator: this.filterOperators[field] || 'contains'
+                    }
+            );
         this.filterChanged.next(query);
     }
 }

--- a/src/main/webapp/app/shared/table-filter/table-filter.component.ts
+++ b/src/main/webapp/app/shared/table-filter/table-filter.component.ts
@@ -2,8 +2,11 @@ import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { Subject } from 'rxjs';
 
 export interface TableField {
+    // name of the field
     name: string;
+    // if filter for the field be displayed
     filter: boolean;
+    // operator applied against the field ('contains', 'equals')
     operator?: string;
 }
 

--- a/src/main/webapp/app/shared/table-filter/table-filter.scss
+++ b/src/main/webapp/app/shared/table-filter/table-filter.scss
@@ -1,0 +1,12 @@
+.filter-field {
+    position: relative;
+    .filter-icon {
+        right: 0.4rem;
+        top: 0.6rem;
+        position: absolute;
+        color: #bbb;
+    }
+    input {
+        padding-right: 1.5rem;
+    }
+}

--- a/tslint.json
+++ b/tslint.json
@@ -102,7 +102,7 @@
         "space-before-function-paren": [true, "never"],
 
         "directive-selector": [true, "attribute", "jhi", "camelCase"],
-        "component-selector": [true, "element", "jhi", "kebab-case"],
+        "component-selector": [true, "element", "jhi", "kebab-case", "camelCase"],
         "use-input-property-decorator": true,
         "use-output-property-decorator": true,
         "use-host-property-decorator": true,


### PR DESCRIPTION
Input for filter is implemented in a separate component `TableFilterComponent`, how the data is filtered is left for the entity component to decide.

Filtering are added to Skill & LevelSkill entities in this pull requests. Adding filtering to other entities later will also be straightforward.

For Skill entity, data are server-side filtered. For LevelSkill entity, data are filtered in frontend code at the moment, as filtering for relationship-entities is not supported in backend yet. Frontend-filtering requires disabling pagination, in order to work, which might cause performance problem in the future. We want to refrain from editing relationship-entities in the future anyway. 