### PR TITLE
[EDO-198] List available trainings in skill details

### DIFF
--- a/.jhipster/Skill.json
+++ b/.jhipster/Skill.json
@@ -19,6 +19,13 @@
             "otherEntityName": "levelSkill",
             "relationshipType": "one-to-many",
             "otherEntityRelationshipName": "skill"
+        },
+        {
+            "relationshipName": "trainings",
+            "otherEntityName": "training",
+            "relationshipType": "many-to-many",
+            "ownerSide": false,
+            "otherEntityRelationshipName": "skill"
         }
     ],
     "fields": [

--- a/.jhipster/Training.json
+++ b/.jhipster/Training.json
@@ -31,11 +31,19 @@
         },
         {
             "fieldName": "contactPerson",
-            "fieldType": "String"
+            "fieldType": "String",
+            "fieldValidateRules": [
+                "maxlength"
+            ],
+            "fieldValidateRulesMaxlength": 255
         },
         {
             "fieldName": "link",
-            "fieldType": "String"
+            "fieldType": "String",
+            "fieldValidateRules": [
+                "maxlength"
+            ],
+            "fieldValidateRulesMaxlength": 255
         },
         {
             "fieldName": "validUntil",

--- a/.jhipster/Training.json
+++ b/.jhipster/Training.json
@@ -1,0 +1,58 @@
+{
+    "fluentMethods": true,
+    "clientRootFolder": "",
+    "relationships": [
+        {
+            "relationshipName": "skill",
+            "otherEntityName": "skill",
+            "relationshipType": "many-to-many",
+            "ownerSide": true,
+            "otherEntityRelationshipName": "trainings",
+            "otherEntityField": "title"
+        }
+    ],
+    "fields": [
+        {
+            "fieldName": "title",
+            "fieldType": "String",
+            "fieldValidateRules": [
+                "required",
+                "maxlength"
+            ],
+            "fieldValidateRulesMaxlength": 80
+        },
+        {
+            "fieldName": "description",
+            "fieldType": "String",
+            "fieldValidateRules": [
+                "maxlength"
+            ],
+            "fieldValidateRulesMaxlength": 100
+        },
+        {
+            "fieldName": "contactPerson",
+            "fieldType": "String"
+        },
+        {
+            "fieldName": "link",
+            "fieldType": "String"
+        },
+        {
+            "fieldName": "validUntil",
+            "fieldType": "Instant"
+        },
+        {
+            "fieldName": "isOfficial",
+            "fieldType": "Boolean",
+            "fieldValidateRules": [
+                "required"
+            ]
+        }
+
+    ],
+    "dto": "mapstruct",
+    "service": "serviceImpl",
+    "entityTableName": "training",
+    "jpaMetamodelFiltering": true,
+    "pagination": "infinite-scroll"
+}

--- a/.jhipster/Training.json
+++ b/.jhipster/Training.json
@@ -41,9 +41,11 @@
             "fieldName": "link",
             "fieldType": "String",
             "fieldValidateRules": [
-                "maxlength"
+                "maxlength",
+                "pattern"
             ],
-            "fieldValidateRulesMaxlength": 255
+            "fieldValidateRulesMaxlength": 255,
+            "fieldValidateRulesPattern": "^(?:http(s)?://)?[\\w.-]+(?:\\.[\\w\\.-]+)+[\\w\\-\\._~:/?#\\[\\]@!\\$&'\\(\\)\\*\\+,;=.]+$"
         },
         {
             "fieldName": "validUntil",

--- a/src/main/java/de/otto/teamdojo/config/CacheConfiguration.java
+++ b/src/main/java/de/otto/teamdojo/config/CacheConfiguration.java
@@ -69,6 +69,7 @@ public class CacheConfiguration {
             cm.createCache(de.otto.teamdojo.domain.Image.class.getName(), jcacheConfiguration);
             cm.createCache(de.otto.teamdojo.domain.Training.class.getName(), jcacheConfiguration);
             cm.createCache(de.otto.teamdojo.domain.Training.class.getName() + ".skills", jcacheConfiguration);
+            cm.createCache(de.otto.teamdojo.domain.Skill.class.getName() + ".trainings", jcacheConfiguration);
             // jhipster-needle-ehcache-add-entry
         };
     }

--- a/src/main/java/de/otto/teamdojo/config/CacheConfiguration.java
+++ b/src/main/java/de/otto/teamdojo/config/CacheConfiguration.java
@@ -67,6 +67,8 @@ public class CacheConfiguration {
             cm.createCache(de.otto.teamdojo.domain.Comment.class.getName(), jcacheConfiguration);
             cm.createCache(de.otto.teamdojo.domain.Activity.class.getName(), jcacheConfiguration);
             cm.createCache(de.otto.teamdojo.domain.Image.class.getName(), jcacheConfiguration);
+            cm.createCache(de.otto.teamdojo.domain.Training.class.getName(), jcacheConfiguration);
+            cm.createCache(de.otto.teamdojo.domain.Training.class.getName() + ".skills", jcacheConfiguration);
             // jhipster-needle-ehcache-add-entry
         };
     }

--- a/src/main/java/de/otto/teamdojo/config/SecurityConfiguration.java
+++ b/src/main/java/de/otto/teamdojo/config/SecurityConfiguration.java
@@ -160,6 +160,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
             .antMatchers(HttpMethod.GET, "/api/images/**").permitAll()
             .antMatchers(HttpMethod.PUT, "/api/images").permitAll()
             .antMatchers(HttpMethod.POST, "/api/images").permitAll()
+            .antMatchers(HttpMethod.GET, "/api/trainings/**").permitAll()
             .antMatchers("/api/register").permitAll()
             .antMatchers("/api/activate").permitAll()
             .antMatchers("/api/authenticate").permitAll()

--- a/src/main/java/de/otto/teamdojo/domain/Skill.java
+++ b/src/main/java/de/otto/teamdojo/domain/Skill.java
@@ -1,14 +1,16 @@
 package de.otto.teamdojo.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 
 import javax.persistence.*;
 import javax.validation.constraints.*;
+
 import java.io.Serializable;
 import java.util.HashSet;
-import java.util.Objects;
 import java.util.Set;
+import java.util.Objects;
 
 /**
  * A Skill.
@@ -54,9 +56,14 @@ public class Skill implements Serializable {
     @Column(name = "score", nullable = false)
     private Integer score;
 
-    @DecimalMin(value = "0") @DecimalMax(value = "5") @Column(name = "rate_score") private Double rateScore;
+    @DecimalMin(value = "0")
+    @DecimalMax(value = "5")
+    @Column(name = "rate_score")
+    private Double rateScore;
 
-    @Min(value = 0) @Column(name = "rate_count") private Integer rateCount;
+    @Min(value = 0)
+    @Column(name = "rate_count")
+    private Integer rateCount;
 
     @OneToMany(mappedBy = "skill")
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
@@ -69,6 +76,11 @@ public class Skill implements Serializable {
     @OneToMany(mappedBy = "skill")
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     private Set<LevelSkill> levels = new HashSet<>();
+
+    @ManyToMany(mappedBy = "skills")
+    @JsonIgnore
+    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
+    private Set<Training> trainings = new HashSet<>();
 
     // jhipster-needle-entity-add-field - JHipster will add fields here, do not remove
     public Long getId() {
@@ -270,6 +282,31 @@ public class Skill implements Serializable {
     public void setLevels(Set<LevelSkill> levelSkills) {
         this.levels = levelSkills;
     }
+
+    public Set<Training> getTrainings() {
+        return trainings;
+    }
+
+    public Skill trainings(Set<Training> trainings) {
+        this.trainings = trainings;
+        return this;
+    }
+
+    public Skill addTrainings(Training training) {
+        this.trainings.add(training);
+        training.getSkills().add(this);
+        return this;
+    }
+
+    public Skill removeTrainings(Training training) {
+        this.trainings.remove(training);
+        training.getSkills().remove(this);
+        return this;
+    }
+
+    public void setTrainings(Set<Training> trainings) {
+        this.trainings = trainings;
+    }
     // jhipster-needle-entity-add-getters-setters - JHipster will add getters and setters here, do not remove
 
     @Override
@@ -303,7 +340,6 @@ public class Skill implements Serializable {
             ", expiryPeriod='" + getExpiryPeriod() + "'" +
             ", contact='" + getContact() + "'" +
             ", score=" + getScore() +
-            ", contact='" + getContact() + "'" +
             ", rateScore=" + getRateScore() +
             ", rateCount=" + getRateCount() +
             "}";

--- a/src/main/java/de/otto/teamdojo/domain/Training.java
+++ b/src/main/java/de/otto/teamdojo/domain/Training.java
@@ -1,0 +1,204 @@
+package de.otto.teamdojo.domain;
+
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+
+import javax.persistence.*;
+import javax.validation.constraints.*;
+
+import java.io.Serializable;
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.Objects;
+
+/**
+ * A Training.
+ */
+@Entity
+@Table(name = "training")
+@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
+public class Training implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "sequenceGenerator")
+    @SequenceGenerator(name = "sequenceGenerator")
+    private Long id;
+
+    @NotNull
+    @Size(max = 80)
+    @Column(name = "title", length = 80, nullable = false)
+    private String title;
+
+    @Size(max = 100)
+    @Column(name = "description", length = 100)
+    private String description;
+
+    @Column(name = "contact_person")
+    private String contactPerson;
+
+    @Column(name = "jhi_link")
+    private String link;
+
+    @Column(name = "valid_until")
+    private Instant validUntil;
+
+    @NotNull
+    @Column(name = "is_official", nullable = false)
+    private Boolean isOfficial;
+
+    @ManyToMany
+    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
+    @JoinTable(name = "training_skill",
+               joinColumns = @JoinColumn(name="trainings_id", referencedColumnName="id"),
+               inverseJoinColumns = @JoinColumn(name="skills_id", referencedColumnName="id"))
+    private Set<Skill> skills = new HashSet<>();
+
+    // jhipster-needle-entity-add-field - JHipster will add fields here, do not remove
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public Training title(String title) {
+        this.title = title;
+        return this;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public Training description(String description) {
+        this.description = description;
+        return this;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getContactPerson() {
+        return contactPerson;
+    }
+
+    public Training contactPerson(String contactPerson) {
+        this.contactPerson = contactPerson;
+        return this;
+    }
+
+    public void setContactPerson(String contactPerson) {
+        this.contactPerson = contactPerson;
+    }
+
+    public String getLink() {
+        return link;
+    }
+
+    public Training link(String link) {
+        this.link = link;
+        return this;
+    }
+
+    public void setLink(String link) {
+        this.link = link;
+    }
+
+    public Instant getValidUntil() {
+        return validUntil;
+    }
+
+    public Training validUntil(Instant validUntil) {
+        this.validUntil = validUntil;
+        return this;
+    }
+
+    public void setValidUntil(Instant validUntil) {
+        this.validUntil = validUntil;
+    }
+
+    public Boolean isIsOfficial() {
+        return isOfficial;
+    }
+
+    public Training isOfficial(Boolean isOfficial) {
+        this.isOfficial = isOfficial;
+        return this;
+    }
+
+    public void setIsOfficial(Boolean isOfficial) {
+        this.isOfficial = isOfficial;
+    }
+
+    public Set<Skill> getSkills() {
+        return skills;
+    }
+
+    public Training skills(Set<Skill> skills) {
+        this.skills = skills;
+        return this;
+    }
+
+    public Training addSkill(Skill skill) {
+        this.skills.add(skill);
+        skill.getTrainings().add(this);
+        return this;
+    }
+
+    public Training removeSkill(Skill skill) {
+        this.skills.remove(skill);
+        skill.getTrainings().remove(this);
+        return this;
+    }
+
+    public void setSkills(Set<Skill> skills) {
+        this.skills = skills;
+    }
+    // jhipster-needle-entity-add-getters-setters - JHipster will add getters and setters here, do not remove
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Training training = (Training) o;
+        if (training.getId() == null || getId() == null) {
+            return false;
+        }
+        return Objects.equals(getId(), training.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(getId());
+    }
+
+    @Override
+    public String toString() {
+        return "Training{" +
+            "id=" + getId() +
+            ", title='" + getTitle() + "'" +
+            ", description='" + getDescription() + "'" +
+            ", contactPerson='" + getContactPerson() + "'" +
+            ", link='" + getLink() + "'" +
+            ", validUntil='" + getValidUntil() + "'" +
+            ", isOfficial='" + isIsOfficial() + "'" +
+            "}";
+    }
+}

--- a/src/main/java/de/otto/teamdojo/domain/Training.java
+++ b/src/main/java/de/otto/teamdojo/domain/Training.java
@@ -41,6 +41,7 @@ public class Training implements Serializable {
     private String contactPerson;
 
     @Size(max = 255)
+    @Pattern(regexp = "^(?:http(s)?://)?[\\w.-]+(?:\\.[\\w\\.-]+)+[\\w\\-\\._~:/?#\\[\\]@!\\$&'\\(\\)\\*\\+,;=.]+$")
     @Column(name = "jhi_link", length = 255)
     private String link;
 

--- a/src/main/java/de/otto/teamdojo/domain/Training.java
+++ b/src/main/java/de/otto/teamdojo/domain/Training.java
@@ -36,10 +36,12 @@ public class Training implements Serializable {
     @Column(name = "description", length = 100)
     private String description;
 
-    @Column(name = "contact_person")
+    @Size(max = 255)
+    @Column(name = "contact_person", length = 255)
     private String contactPerson;
 
-    @Column(name = "jhi_link")
+    @Size(max = 255)
+    @Column(name = "jhi_link", length = 255)
     private String link;
 
     @Column(name = "valid_until")

--- a/src/main/java/de/otto/teamdojo/repository/SkillRepository.java
+++ b/src/main/java/de/otto/teamdojo/repository/SkillRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.data.jpa.repository.*;
 
 import java.util.List;
 

--- a/src/main/java/de/otto/teamdojo/repository/TrainingRepository.java
+++ b/src/main/java/de/otto/teamdojo/repository/TrainingRepository.java
@@ -1,0 +1,29 @@
+package de.otto.teamdojo.repository;
+
+import de.otto.teamdojo.domain.Training;
+import org.springframework.stereotype.Repository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.*;
+import org.springframework.data.repository.query.Param;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Spring Data JPA repository for the Training entity.
+ */
+@SuppressWarnings("unused")
+@Repository
+public interface TrainingRepository extends JpaRepository<Training, Long>, JpaSpecificationExecutor<Training> {
+
+    @Query(value = "select distinct training from Training training left join fetch training.skills",
+        countQuery = "select count(distinct training) from Training training")
+    Page<Training> findAllWithEagerRelationships(Pageable pageable);
+
+    @Query(value = "select distinct training from Training training left join fetch training.skills")
+    List<Training> findAllWithEagerRelationships();
+
+    @Query("select training from Training training left join fetch training.skills where training.id =:id")
+    Optional<Training> findOneWithEagerRelationships(@Param("id") Long id);
+
+}

--- a/src/main/java/de/otto/teamdojo/service/SkillQueryService.java
+++ b/src/main/java/de/otto/teamdojo/service/SkillQueryService.java
@@ -1,11 +1,7 @@
 package de.otto.teamdojo.service;
 
-import de.otto.teamdojo.domain.*;
-import de.otto.teamdojo.repository.SkillRepository;
-import de.otto.teamdojo.service.dto.SkillCriteria;
-import de.otto.teamdojo.service.dto.SkillDTO;
-import de.otto.teamdojo.service.mapper.SkillMapper;
-import io.github.jhipster.service.QueryService;
+import java.util.List;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Page;
@@ -14,7 +10,15 @@ import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
+import io.github.jhipster.service.QueryService;
+
+import de.otto.teamdojo.domain.Skill;
+import de.otto.teamdojo.domain.*; // for static metamodels
+import de.otto.teamdojo.repository.SkillRepository;
+import de.otto.teamdojo.service.dto.SkillCriteria;
+
+import de.otto.teamdojo.service.dto.SkillDTO;
+import de.otto.teamdojo.service.mapper.SkillMapper;
 
 /**
  * Service for executing complex queries for Skill entities in the database.
@@ -107,6 +111,9 @@ public class SkillQueryService extends QueryService<Skill> {
             }
             if (criteria.getLevelsId() != null) {
                 specification = specification.and(buildReferringEntitySpecification(criteria.getLevelsId(), Skill_.levels, LevelSkill_.id));
+            }
+            if (criteria.getTrainingsId() != null) {
+                specification = specification.and(buildReferringEntitySpecification(criteria.getTrainingsId(), Skill_.trainings, Training_.id));
             }
         }
         return specification;

--- a/src/main/java/de/otto/teamdojo/service/TrainingQueryService.java
+++ b/src/main/java/de/otto/teamdojo/service/TrainingQueryService.java
@@ -1,0 +1,104 @@
+package de.otto.teamdojo.service;
+
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import io.github.jhipster.service.QueryService;
+
+import de.otto.teamdojo.domain.Training;
+import de.otto.teamdojo.domain.*; // for static metamodels
+import de.otto.teamdojo.repository.TrainingRepository;
+import de.otto.teamdojo.service.dto.TrainingCriteria;
+
+import de.otto.teamdojo.service.dto.TrainingDTO;
+import de.otto.teamdojo.service.mapper.TrainingMapper;
+
+/**
+ * Service for executing complex queries for Training entities in the database.
+ * The main input is a {@link TrainingCriteria} which gets converted to {@link Specification},
+ * in a way that all the filters must apply.
+ * It returns a {@link List} of {@link TrainingDTO} or a {@link Page} of {@link TrainingDTO} which fulfills the criteria.
+ */
+@Service
+@Transactional(readOnly = true)
+public class TrainingQueryService extends QueryService<Training> {
+
+    private final Logger log = LoggerFactory.getLogger(TrainingQueryService.class);
+
+    private final TrainingRepository trainingRepository;
+
+    private final TrainingMapper trainingMapper;
+
+    public TrainingQueryService(TrainingRepository trainingRepository, TrainingMapper trainingMapper) {
+        this.trainingRepository = trainingRepository;
+        this.trainingMapper = trainingMapper;
+    }
+
+    /**
+     * Return a {@link List} of {@link TrainingDTO} which matches the criteria from the database
+     * @param criteria The object which holds all the filters, which the entities should match.
+     * @return the matching entities.
+     */
+    @Transactional(readOnly = true)
+    public List<TrainingDTO> findByCriteria(TrainingCriteria criteria) {
+        log.debug("find by criteria : {}", criteria);
+        final Specification<Training> specification = createSpecification(criteria);
+        return trainingMapper.toDto(trainingRepository.findAll(specification));
+    }
+
+    /**
+     * Return a {@link Page} of {@link TrainingDTO} which matches the criteria from the database
+     * @param criteria The object which holds all the filters, which the entities should match.
+     * @param page The page, which should be returned.
+     * @return the matching entities.
+     */
+    @Transactional(readOnly = true)
+    public Page<TrainingDTO> findByCriteria(TrainingCriteria criteria, Pageable page) {
+        log.debug("find by criteria : {}, page: {}", criteria, page);
+        final Specification<Training> specification = createSpecification(criteria);
+        return trainingRepository.findAll(specification, page)
+            .map(trainingMapper::toDto);
+    }
+
+    /**
+     * Function to convert TrainingCriteria to a {@link Specification}
+     */
+    private Specification<Training> createSpecification(TrainingCriteria criteria) {
+        Specification<Training> specification = Specification.where(null);
+        if (criteria != null) {
+            if (criteria.getId() != null) {
+                specification = specification.and(buildSpecification(criteria.getId(), Training_.id));
+            }
+            if (criteria.getTitle() != null) {
+                specification = specification.and(buildStringSpecification(criteria.getTitle(), Training_.title));
+            }
+            if (criteria.getDescription() != null) {
+                specification = specification.and(buildStringSpecification(criteria.getDescription(), Training_.description));
+            }
+            if (criteria.getContactPerson() != null) {
+                specification = specification.and(buildStringSpecification(criteria.getContactPerson(), Training_.contactPerson));
+            }
+            if (criteria.getLink() != null) {
+                specification = specification.and(buildStringSpecification(criteria.getLink(), Training_.link));
+            }
+            if (criteria.getValidUntil() != null) {
+                specification = specification.and(buildRangeSpecification(criteria.getValidUntil(), Training_.validUntil));
+            }
+            if (criteria.getIsOfficial() != null) {
+                specification = specification.and(buildSpecification(criteria.getIsOfficial(), Training_.isOfficial));
+            }
+            if (criteria.getSkillId() != null) {
+                specification = specification.and(buildReferringEntitySpecification(criteria.getSkillId(), Training_.skills, Skill_.id));
+            }
+        }
+        return specification;
+    }
+
+}

--- a/src/main/java/de/otto/teamdojo/service/TrainingService.java
+++ b/src/main/java/de/otto/teamdojo/service/TrainingService.java
@@ -1,0 +1,52 @@
+package de.otto.teamdojo.service;
+
+import de.otto.teamdojo.service.dto.TrainingDTO;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Optional;
+
+/**
+ * Service Interface for managing Training.
+ */
+public interface TrainingService {
+
+    /**
+     * Save a training.
+     *
+     * @param trainingDTO the entity to save
+     * @return the persisted entity
+     */
+    TrainingDTO save(TrainingDTO trainingDTO);
+
+    /**
+     * Get all the trainings.
+     *
+     * @param pageable the pagination information
+     * @return the list of entities
+     */
+    Page<TrainingDTO> findAll(Pageable pageable);
+
+    /**
+     * Get all the Training with eager load of many-to-many relationships.
+     *
+     * @return the list of entities
+     */
+    Page<TrainingDTO> findAllWithEagerRelationships(Pageable pageable);
+    
+    /**
+     * Get the "id" training.
+     *
+     * @param id the id of the entity
+     * @return the entity
+     */
+    Optional<TrainingDTO> findOne(Long id);
+
+    /**
+     * Delete the "id" training.
+     *
+     * @param id the id of the entity
+     */
+    void delete(Long id);
+}

--- a/src/main/java/de/otto/teamdojo/service/dto/SkillCriteria.java
+++ b/src/main/java/de/otto/teamdojo/service/dto/SkillCriteria.java
@@ -1,8 +1,15 @@
 package de.otto.teamdojo.service.dto;
 
-import io.github.jhipster.service.filter.*;
-
 import java.io.Serializable;
+
+import io.github.jhipster.service.filter.BooleanFilter;
+import io.github.jhipster.service.filter.DoubleFilter;
+import io.github.jhipster.service.filter.Filter;
+import io.github.jhipster.service.filter.FloatFilter;
+import io.github.jhipster.service.filter.IntegerFilter;
+import io.github.jhipster.service.filter.LongFilter;
+import io.github.jhipster.service.filter.StringFilter;
+
 
 /**
  * Criteria class for the Skill entity. This class is used in SkillResource to
@@ -41,6 +48,8 @@ public class SkillCriteria implements Serializable {
     private LongFilter badgesId;
 
     private LongFilter levelsId;
+
+    private LongFilter trainingsId;
 
     public SkillCriteria() {
     }
@@ -149,6 +158,14 @@ public class SkillCriteria implements Serializable {
         this.levelsId = levelsId;
     }
 
+    public LongFilter getTrainingsId() {
+        return trainingsId;
+    }
+
+    public void setTrainingsId(LongFilter trainingsId) {
+        this.trainingsId = trainingsId;
+    }
+
     @Override
     public String toString() {
         return "SkillCriteria{" +
@@ -165,6 +182,7 @@ public class SkillCriteria implements Serializable {
             (teamsId != null ? "teamsId=" + teamsId + ", " : "") +
             (badgesId != null ? "badgesId=" + badgesId + ", " : "") +
             (levelsId != null ? "levelsId=" + levelsId + ", " : "") +
+            (trainingsId != null ? "trainingsId=" + trainingsId + ", " : "") +
             "}";
     }
 

--- a/src/main/java/de/otto/teamdojo/service/dto/TrainingCriteria.java
+++ b/src/main/java/de/otto/teamdojo/service/dto/TrainingCriteria.java
@@ -1,0 +1,126 @@
+package de.otto.teamdojo.service.dto;
+
+import java.io.Serializable;
+import io.github.jhipster.service.filter.BooleanFilter;
+import io.github.jhipster.service.filter.DoubleFilter;
+import io.github.jhipster.service.filter.Filter;
+import io.github.jhipster.service.filter.FloatFilter;
+import io.github.jhipster.service.filter.IntegerFilter;
+import io.github.jhipster.service.filter.LongFilter;
+import io.github.jhipster.service.filter.StringFilter;
+
+import io.github.jhipster.service.filter.InstantFilter;
+
+
+
+
+/**
+ * Criteria class for the Training entity. This class is used in TrainingResource to
+ * receive all the possible filtering options from the Http GET request parameters.
+ * For example the following could be a valid requests:
+ * <code> /trainings?id.greaterThan=5&amp;attr1.contains=something&amp;attr2.specified=false</code>
+ * As Spring is unable to properly convert the types, unless specific {@link Filter} class are used, we need to use
+ * fix type specific filters.
+ */
+public class TrainingCriteria implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+
+    private LongFilter id;
+
+    private StringFilter title;
+
+    private StringFilter description;
+
+    private StringFilter contactPerson;
+
+    private StringFilter link;
+
+    private InstantFilter validUntil;
+
+    private BooleanFilter isOfficial;
+
+    private LongFilter skillId;
+
+    public TrainingCriteria() {
+    }
+
+    public LongFilter getId() {
+        return id;
+    }
+
+    public void setId(LongFilter id) {
+        this.id = id;
+    }
+
+    public StringFilter getTitle() {
+        return title;
+    }
+
+    public void setTitle(StringFilter title) {
+        this.title = title;
+    }
+
+    public StringFilter getDescription() {
+        return description;
+    }
+
+    public void setDescription(StringFilter description) {
+        this.description = description;
+    }
+
+    public StringFilter getContactPerson() {
+        return contactPerson;
+    }
+
+    public void setContactPerson(StringFilter contactPerson) {
+        this.contactPerson = contactPerson;
+    }
+
+    public StringFilter getLink() {
+        return link;
+    }
+
+    public void setLink(StringFilter link) {
+        this.link = link;
+    }
+
+    public InstantFilter getValidUntil() {
+        return validUntil;
+    }
+
+    public void setValidUntil(InstantFilter validUntil) {
+        this.validUntil = validUntil;
+    }
+
+    public BooleanFilter getIsOfficial() {
+        return isOfficial;
+    }
+
+    public void setIsOfficial(BooleanFilter isOfficial) {
+        this.isOfficial = isOfficial;
+    }
+
+    public LongFilter getSkillId() {
+        return skillId;
+    }
+
+    public void setSkillId(LongFilter skillId) {
+        this.skillId = skillId;
+    }
+
+    @Override
+    public String toString() {
+        return "TrainingCriteria{" +
+                (id != null ? "id=" + id + ", " : "") +
+                (title != null ? "title=" + title + ", " : "") +
+                (description != null ? "description=" + description + ", " : "") +
+                (contactPerson != null ? "contactPerson=" + contactPerson + ", " : "") +
+                (link != null ? "link=" + link + ", " : "") +
+            (validUntil != null ? "validUntil=" + validUntil + ", " : "") +
+                (isOfficial != null ? "isOfficial=" + isOfficial + ", " : "") +
+                (skillId != null ? "skillId=" + skillId + ", " : "") +
+            "}";
+    }
+
+}

--- a/src/main/java/de/otto/teamdojo/service/dto/TrainingDTO.java
+++ b/src/main/java/de/otto/teamdojo/service/dto/TrainingDTO.java
@@ -1,0 +1,132 @@
+package de.otto.teamdojo.service.dto;
+
+import java.time.Instant;
+import javax.validation.constraints.*;
+import java.io.Serializable;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.Objects;
+
+/**
+ * A DTO for the Training entity.
+ */
+public class TrainingDTO implements Serializable {
+
+    private Long id;
+
+    @NotNull
+    @Size(max = 80)
+    private String title;
+
+    @Size(max = 100)
+    private String description;
+
+    private String contactPerson;
+
+    private String link;
+
+    private Instant validUntil;
+
+    @NotNull
+    private Boolean isOfficial;
+
+    private Set<SkillDTO> skills = new HashSet<>();
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getContactPerson() {
+        return contactPerson;
+    }
+
+    public void setContactPerson(String contactPerson) {
+        this.contactPerson = contactPerson;
+    }
+
+    public String getLink() {
+        return link;
+    }
+
+    public void setLink(String link) {
+        this.link = link;
+    }
+
+    public Instant getValidUntil() {
+        return validUntil;
+    }
+
+    public void setValidUntil(Instant validUntil) {
+        this.validUntil = validUntil;
+    }
+
+    public Boolean isIsOfficial() {
+        return isOfficial;
+    }
+
+    public void setIsOfficial(Boolean isOfficial) {
+        this.isOfficial = isOfficial;
+    }
+
+    public Set<SkillDTO> getSkills() {
+        return skills;
+    }
+
+    public void setSkills(Set<SkillDTO> skills) {
+        this.skills = skills;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        TrainingDTO trainingDTO = (TrainingDTO) o;
+        if (trainingDTO.getId() == null || getId() == null) {
+            return false;
+        }
+        return Objects.equals(getId(), trainingDTO.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(getId());
+    }
+
+    @Override
+    public String toString() {
+        return "TrainingDTO{" +
+            "id=" + getId() +
+            ", title='" + getTitle() + "'" +
+            ", description='" + getDescription() + "'" +
+            ", contactPerson='" + getContactPerson() + "'" +
+            ", link='" + getLink() + "'" +
+            ", validUntil='" + getValidUntil() + "'" +
+            ", isOfficial='" + isIsOfficial() + "'" +
+            "}";
+    }
+}

--- a/src/main/java/de/otto/teamdojo/service/dto/TrainingDTO.java
+++ b/src/main/java/de/otto/teamdojo/service/dto/TrainingDTO.java
@@ -25,6 +25,7 @@ public class TrainingDTO implements Serializable {
     private String contactPerson;
 
     @Size(max = 255)
+    @Pattern(regexp = "^(?:http(s)?://)?[\\w.-]+(?:\\.[\\w\\.-]+)+[\\w\\-\\._~:/?#\\[\\]@!\\$&'\\(\\)\\*\\+,;=.]+$")
     private String link;
 
     private Instant validUntil;

--- a/src/main/java/de/otto/teamdojo/service/dto/TrainingDTO.java
+++ b/src/main/java/de/otto/teamdojo/service/dto/TrainingDTO.java
@@ -21,8 +21,10 @@ public class TrainingDTO implements Serializable {
     @Size(max = 100)
     private String description;
 
+    @Size(max = 255)
     private String contactPerson;
 
+    @Size(max = 255)
     private String link;
 
     private Instant validUntil;

--- a/src/main/java/de/otto/teamdojo/service/impl/TrainingServiceImpl.java
+++ b/src/main/java/de/otto/teamdojo/service/impl/TrainingServiceImpl.java
@@ -1,0 +1,98 @@
+package de.otto.teamdojo.service.impl;
+
+import de.otto.teamdojo.service.TrainingService;
+import de.otto.teamdojo.domain.Training;
+import de.otto.teamdojo.repository.TrainingRepository;
+import de.otto.teamdojo.service.dto.TrainingDTO;
+import de.otto.teamdojo.service.mapper.TrainingMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+/**
+ * Service Implementation for managing Training.
+ */
+@Service
+@Transactional
+public class TrainingServiceImpl implements TrainingService {
+
+    private final Logger log = LoggerFactory.getLogger(TrainingServiceImpl.class);
+
+    private final TrainingRepository trainingRepository;
+
+    private final TrainingMapper trainingMapper;
+
+    public TrainingServiceImpl(TrainingRepository trainingRepository, TrainingMapper trainingMapper) {
+        this.trainingRepository = trainingRepository;
+        this.trainingMapper = trainingMapper;
+    }
+
+    /**
+     * Save a training.
+     *
+     * @param trainingDTO the entity to save
+     * @return the persisted entity
+     */
+    @Override
+    public TrainingDTO save(TrainingDTO trainingDTO) {
+        log.debug("Request to save Training : {}", trainingDTO);
+        Training training = trainingMapper.toEntity(trainingDTO);
+        training = trainingRepository.save(training);
+        return trainingMapper.toDto(training);
+    }
+
+    /**
+     * Get all the trainings.
+     *
+     * @param pageable the pagination information
+     * @return the list of entities
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public Page<TrainingDTO> findAll(Pageable pageable) {
+        log.debug("Request to get all Trainings");
+        return trainingRepository.findAll(pageable)
+            .map(trainingMapper::toDto);
+    }
+
+    /**
+     * Get all the Training with eager load of many-to-many relationships.
+     *
+     * @return the list of entities
+     */
+    public Page<TrainingDTO> findAllWithEagerRelationships(Pageable pageable) {
+        return trainingRepository.findAllWithEagerRelationships(pageable).map(trainingMapper::toDto);
+    }
+    
+
+    /**
+     * Get one training by id.
+     *
+     * @param id the id of the entity
+     * @return the entity
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<TrainingDTO> findOne(Long id) {
+        log.debug("Request to get Training : {}", id);
+        return trainingRepository.findOneWithEagerRelationships(id)
+            .map(trainingMapper::toDto);
+    }
+
+    /**
+     * Delete the training by id.
+     *
+     * @param id the id of the entity
+     */
+    @Override
+    public void delete(Long id) {
+        log.debug("Request to delete Training : {}", id);
+        trainingRepository.deleteById(id);
+    }
+}

--- a/src/main/java/de/otto/teamdojo/service/mapper/SkillMapper.java
+++ b/src/main/java/de/otto/teamdojo/service/mapper/SkillMapper.java
@@ -1,9 +1,9 @@
 package de.otto.teamdojo.service.mapper;
 
-import de.otto.teamdojo.domain.Skill;
+import de.otto.teamdojo.domain.*;
 import de.otto.teamdojo.service.dto.SkillDTO;
-import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
+
+import org.mapstruct.*;
 
 /**
  * Mapper for the entity Skill and its DTO SkillDTO.
@@ -15,6 +15,7 @@ public interface SkillMapper extends EntityMapper<SkillDTO, Skill> {
     @Mapping(target = "teams", ignore = true)
     @Mapping(target = "badges", ignore = true)
     @Mapping(target = "levels", ignore = true)
+    @Mapping(target = "trainings", ignore = true)
     Skill toEntity(SkillDTO skillDTO);
 
     default Skill fromId(Long id) {

--- a/src/main/java/de/otto/teamdojo/service/mapper/TrainingMapper.java
+++ b/src/main/java/de/otto/teamdojo/service/mapper/TrainingMapper.java
@@ -1,0 +1,24 @@
+package de.otto.teamdojo.service.mapper;
+
+import de.otto.teamdojo.domain.*;
+import de.otto.teamdojo.service.dto.TrainingDTO;
+
+import org.mapstruct.*;
+
+/**
+ * Mapper for the entity Training and its DTO TrainingDTO.
+ */
+@Mapper(componentModel = "spring", uses = {SkillMapper.class})
+public interface TrainingMapper extends EntityMapper<TrainingDTO, Training> {
+
+
+
+    default Training fromId(Long id) {
+        if (id == null) {
+            return null;
+        }
+        Training training = new Training();
+        training.setId(id);
+        return training;
+    }
+}

--- a/src/main/java/de/otto/teamdojo/web/rest/SkillResource.java
+++ b/src/main/java/de/otto/teamdojo/web/rest/SkillResource.java
@@ -1,14 +1,14 @@
 package de.otto.teamdojo.web.rest;
 
 import com.codahale.metrics.annotation.Timed;
-import de.otto.teamdojo.service.SkillQueryService;
 import de.otto.teamdojo.service.SkillService;
-import de.otto.teamdojo.service.dto.SkillCriteria;
-import de.otto.teamdojo.service.dto.SkillDTO;
 import de.otto.teamdojo.service.dto.SkillRateDTO;
 import de.otto.teamdojo.web.rest.errors.BadRequestAlertException;
 import de.otto.teamdojo.web.rest.util.HeaderUtil;
 import de.otto.teamdojo.web.rest.util.PaginationUtil;
+import de.otto.teamdojo.service.dto.SkillDTO;
+import de.otto.teamdojo.service.dto.SkillCriteria;
+import de.otto.teamdojo.service.SkillQueryService;
 import io.github.jhipster.web.util.ResponseUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/de/otto/teamdojo/web/rest/TrainingResource.java
+++ b/src/main/java/de/otto/teamdojo/web/rest/TrainingResource.java
@@ -1,0 +1,133 @@
+package de.otto.teamdojo.web.rest;
+
+import com.codahale.metrics.annotation.Timed;
+import de.otto.teamdojo.service.TrainingService;
+import de.otto.teamdojo.web.rest.errors.BadRequestAlertException;
+import de.otto.teamdojo.web.rest.util.HeaderUtil;
+import de.otto.teamdojo.web.rest.util.PaginationUtil;
+import de.otto.teamdojo.service.dto.TrainingDTO;
+import de.otto.teamdojo.service.dto.TrainingCriteria;
+import de.otto.teamdojo.service.TrainingQueryService;
+import io.github.jhipster.web.util.ResponseUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * REST controller for managing Training.
+ */
+@RestController
+@RequestMapping("/api")
+public class TrainingResource {
+
+    private final Logger log = LoggerFactory.getLogger(TrainingResource.class);
+
+    private static final String ENTITY_NAME = "training";
+
+    private final TrainingService trainingService;
+
+    private final TrainingQueryService trainingQueryService;
+
+    public TrainingResource(TrainingService trainingService, TrainingQueryService trainingQueryService) {
+        this.trainingService = trainingService;
+        this.trainingQueryService = trainingQueryService;
+    }
+
+    /**
+     * POST  /trainings : Create a new training.
+     *
+     * @param trainingDTO the trainingDTO to create
+     * @return the ResponseEntity with status 201 (Created) and with body the new trainingDTO, or with status 400 (Bad Request) if the training has already an ID
+     * @throws URISyntaxException if the Location URI syntax is incorrect
+     */
+    @PostMapping("/trainings")
+    @Timed
+    public ResponseEntity<TrainingDTO> createTraining(@Valid @RequestBody TrainingDTO trainingDTO) throws URISyntaxException {
+        log.debug("REST request to save Training : {}", trainingDTO);
+        if (trainingDTO.getId() != null) {
+            throw new BadRequestAlertException("A new training cannot already have an ID", ENTITY_NAME, "idexists");
+        }
+        TrainingDTO result = trainingService.save(trainingDTO);
+        return ResponseEntity.created(new URI("/api/trainings/" + result.getId()))
+            .headers(HeaderUtil.createEntityCreationAlert(ENTITY_NAME, result.getId().toString()))
+            .body(result);
+    }
+
+    /**
+     * PUT  /trainings : Updates an existing training.
+     *
+     * @param trainingDTO the trainingDTO to update
+     * @return the ResponseEntity with status 200 (OK) and with body the updated trainingDTO,
+     * or with status 400 (Bad Request) if the trainingDTO is not valid,
+     * or with status 500 (Internal Server Error) if the trainingDTO couldn't be updated
+     * @throws URISyntaxException if the Location URI syntax is incorrect
+     */
+    @PutMapping("/trainings")
+    @Timed
+    public ResponseEntity<TrainingDTO> updateTraining(@Valid @RequestBody TrainingDTO trainingDTO) throws URISyntaxException {
+        log.debug("REST request to update Training : {}", trainingDTO);
+        if (trainingDTO.getId() == null) {
+            return createTraining(trainingDTO);
+        }
+        TrainingDTO result = trainingService.save(trainingDTO);
+        return ResponseEntity.ok()
+            .headers(HeaderUtil.createEntityUpdateAlert(ENTITY_NAME, trainingDTO.getId().toString()))
+            .body(result);
+    }
+
+    /**
+     * GET  /trainings : get all the trainings.
+     *
+     * @param pageable the pagination information
+     * @param criteria the criterias which the requested entities should match
+     * @return the ResponseEntity with status 200 (OK) and the list of trainings in body
+     */
+    @GetMapping("/trainings")
+    @Timed
+    public ResponseEntity<List<TrainingDTO>> getAllTrainings(TrainingCriteria criteria, Pageable pageable) {
+        log.debug("REST request to get Trainings by criteria: {}", criteria);
+        Page<TrainingDTO> page = trainingQueryService.findByCriteria(criteria, pageable);
+        HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(page, "/api/trainings");
+        return new ResponseEntity<>(page.getContent(), headers, HttpStatus.OK);
+    }
+
+    /**
+     * GET  /trainings/:id : get the "id" training.
+     *
+     * @param id the id of the trainingDTO to retrieve
+     * @return the ResponseEntity with status 200 (OK) and with body the trainingDTO, or with status 404 (Not Found)
+     */
+    @GetMapping("/trainings/{id}")
+    @Timed
+    public ResponseEntity<TrainingDTO> getTraining(@PathVariable Long id) {
+        log.debug("REST request to get Training : {}", id);
+        Optional<TrainingDTO> trainingDTO = trainingService.findOne(id);
+        return ResponseUtil.wrapOrNotFound(trainingDTO);
+    }
+
+    /**
+     * DELETE  /trainings/:id : delete the "id" training.
+     *
+     * @param id the id of the trainingDTO to delete
+     * @return the ResponseEntity with status 200 (OK)
+     */
+    @DeleteMapping("/trainings/{id}")
+    @Timed
+    public ResponseEntity<Void> deleteTraining(@PathVariable Long id) {
+        log.debug("REST request to delete Training : {}", id);
+        trainingService.delete(id);
+        return ResponseEntity.ok().headers(HeaderUtil.createEntityDeletionAlert(ENTITY_NAME, id.toString())).build();
+    }
+}

--- a/src/main/resources/config/liquibase/changelog/20190121142418_added_entity_Training.xml
+++ b/src/main/resources/config/liquibase/changelog/20190121142418_added_entity_Training.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd
+                        http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+
+    <property name="now" value="now()" dbms="h2"/>
+
+    <property name="now" value="current_timestamp" dbms="postgresql"/>
+
+    <property name="floatType" value="float4" dbms="postgresql, h2"/>
+    <property name="floatType" value="float" dbms="mysql, oracle, mssql"/>
+
+    <!--
+        Added the entity Training.
+    -->
+    <changeSet id="20190121142418-1" author="jhipster">
+        <createTable tableName="training">
+            <column name="id" type="bigint" autoIncrement="${autoIncrement}">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="title" type="varchar(80)">
+                <constraints nullable="false" />
+            </column>
+
+            <column name="description" type="varchar(100)">
+                <constraints nullable="true" />
+            </column>
+
+            <column name="contact_person" type="varchar(255)">
+                <constraints nullable="true" />
+            </column>
+
+            <column name="jhi_link" type="varchar(255)">
+                <constraints nullable="true" />
+            </column>
+
+            <column name="valid_until" type="timestamp">
+                <constraints nullable="true" />
+            </column>
+
+            <column name="is_official" type="boolean">
+                <constraints nullable="false" />
+            </column>
+
+            <!-- jhipster-needle-liquibase-add-column - JHipster will add columns here, do not remove-->
+        </createTable>
+        <dropDefaultValue tableName="training" columnName="valid_until" columnDataType="datetime"/>
+        
+        <createTable tableName="training_skill">
+            <column name="skills_id" type="bigint">
+                <constraints nullable="false"/>
+            </column>
+            <column name="trainings_id" type="bigint">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addPrimaryKey columnNames="trainings_id, skills_id" tableName="training_skill"/>
+        
+    </changeSet>
+    <!-- jhipster-needle-liquibase-add-changeset - JHipster will add changesets here, do not remove-->
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/changelog/20190121142418_added_entity_constraints_Training.xml
+++ b/src/main/resources/config/liquibase/changelog/20190121142418_added_entity_constraints_Training.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+    <!--
+        Added the constraints for entity Training.
+    -->
+    <changeSet id="20190121142418-2" author="jhipster">
+        
+        <addForeignKeyConstraint baseColumnNames="trainings_id"
+                                 baseTableName="training_skill"
+                                 constraintName="fk_training_skill_trainings_id"
+                                 referencedColumnNames="id"
+                                 referencedTableName="training"/>
+        <addForeignKeyConstraint baseColumnNames="skills_id"
+                                 baseTableName="training_skill"
+                                 constraintName="fk_training_skill_skills_id"
+                                 referencedColumnNames="id"
+                                 referencedTableName="skill"/>
+        
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/changelog/20190122103014_added_entity_Training.xml
+++ b/src/main/resources/config/liquibase/changelog/20190122103014_added_entity_Training.xml
@@ -16,7 +16,7 @@
     <!--
         Added the entity Training.
     -->
-    <changeSet id="20190121142418-1" author="jhipster">
+    <changeSet id="20190122103014-1" author="jhipster">
         <createTable tableName="training">
             <column name="id" type="bigint" autoIncrement="${autoIncrement}">
                 <constraints primaryKey="true" nullable="false"/>

--- a/src/main/resources/config/liquibase/changelog/20190122103014_added_entity_constraints_Training.xml
+++ b/src/main/resources/config/liquibase/changelog/20190122103014_added_entity_constraints_Training.xml
@@ -6,7 +6,7 @@
     <!--
         Added the constraints for entity Training.
     -->
-    <changeSet id="20190121142418-2" author="jhipster">
+    <changeSet id="20190122103014-2" author="jhipster">
         
         <addForeignKeyConstraint baseColumnNames="trainings_id"
                                  baseTableName="training_skill"

--- a/src/main/resources/config/liquibase/changelog/20190122103430_added_entity_Training.xml
+++ b/src/main/resources/config/liquibase/changelog/20190122103430_added_entity_Training.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd
+                        http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+
+    <property name="now" value="now()" dbms="h2"/>
+
+    <property name="now" value="current_timestamp" dbms="postgresql"/>
+
+    <property name="floatType" value="float4" dbms="postgresql, h2"/>
+    <property name="floatType" value="float" dbms="mysql, oracle, mssql"/>
+
+    <!--
+        Added the entity Training.
+    -->
+    <changeSet id="20190122103430-1" author="jhipster">
+        <createTable tableName="training">
+            <column name="id" type="bigint" autoIncrement="${autoIncrement}">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="title" type="varchar(80)">
+                <constraints nullable="false" />
+            </column>
+
+            <column name="description" type="varchar(100)">
+                <constraints nullable="true" />
+            </column>
+
+            <column name="contact_person" type="varchar(255)">
+                <constraints nullable="true" />
+            </column>
+
+            <column name="jhi_link" type="varchar(255)">
+                <constraints nullable="true" />
+            </column>
+
+            <column name="valid_until" type="timestamp">
+                <constraints nullable="true" />
+            </column>
+
+            <column name="is_official" type="boolean">
+                <constraints nullable="false" />
+            </column>
+
+            <!-- jhipster-needle-liquibase-add-column - JHipster will add columns here, do not remove-->
+        </createTable>
+        <dropDefaultValue tableName="training" columnName="valid_until" columnDataType="datetime"/>
+        
+        <createTable tableName="training_skill">
+            <column name="skills_id" type="bigint">
+                <constraints nullable="false"/>
+            </column>
+            <column name="trainings_id" type="bigint">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addPrimaryKey columnNames="trainings_id, skills_id" tableName="training_skill"/>
+        
+    </changeSet>
+    <!-- jhipster-needle-liquibase-add-changeset - JHipster will add changesets here, do not remove-->
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/changelog/20190122103430_added_entity_constraints_Training.xml
+++ b/src/main/resources/config/liquibase/changelog/20190122103430_added_entity_constraints_Training.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+    <!--
+        Added the constraints for entity Training.
+    -->
+    <changeSet id="20190122103430-2" author="jhipster">
+        
+        <addForeignKeyConstraint baseColumnNames="trainings_id"
+                                 baseTableName="training_skill"
+                                 constraintName="fk_training_skill_trainings_id"
+                                 referencedColumnNames="id"
+                                 referencedTableName="training"/>
+        <addForeignKeyConstraint baseColumnNames="skills_id"
+                                 baseTableName="training_skill"
+                                 constraintName="fk_training_skill_skills_id"
+                                 referencedColumnNames="id"
+                                 referencedTableName="skill"/>
+        
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/master.xml
+++ b/src/main/resources/config/liquibase/master.xml
@@ -18,7 +18,7 @@
     <include file="config/liquibase/changelog/20180528114846_added_entity_Comment.xml" relativeToChangelogFile="false"/>
     <include file="config/liquibase/changelog/20180529124818_added_entity_Activity.xml" relativeToChangelogFile="false"/>
     <include file="config/liquibase/changelog/20180605123508_added_entity_Image.xml" relativeToChangelogFile="false"/>
-    <include file="config/liquibase/changelog/20190122103014_added_entity_Training.xml" relativeToChangelogFile="false"/>
+    <include file="config/liquibase/changelog/20190122103430_added_entity_Training.xml" relativeToChangelogFile="false"/>
     <!-- jhipster-needle-liquibase-add-changelog - JHipster will add liquibase changelogs here -->
     <include file="config/liquibase/changelog/20180419083624_added_entity_constraints_Team.xml" relativeToChangelogFile="false"/>
     <include file="config/liquibase/changelog/20180419092355_added_entity_constraints_TeamSkill.xml" relativeToChangelogFile="false"/>
@@ -27,7 +27,7 @@
     <include file="config/liquibase/changelog/20180419154302_added_entity_constraints_LevelSkill.xml" relativeToChangelogFile="false"/>
     <include file="config/liquibase/changelog/20180419135514_added_entity_constraints_Badge.xml" relativeToChangelogFile="false"/>
     <include file="config/liquibase/changelog/20180528114846_added_entity_constraints_Comment.xml" relativeToChangelogFile="false"/>
-    <include file="config/liquibase/changelog/20190122103014_added_entity_constraints_Training.xml" relativeToChangelogFile="false"/>
+    <include file="config/liquibase/changelog/20190122103430_added_entity_constraints_Training.xml" relativeToChangelogFile="false"/>
     <!-- jhipster-needle-liquibase-add-constraints-changelog - JHipster will add liquibase constraints changelogs here -->
     <include file="config/liquibase/changelog/20180604134444_initial_demo_data.xml" relativeToChangelogFile="false"/>
     <include file="config/liquibase/changelog/20180612164700_extend_skill_descriptions_length.xml" relativeToChangelogFile="false"/>

--- a/src/main/resources/config/liquibase/master.xml
+++ b/src/main/resources/config/liquibase/master.xml
@@ -18,6 +18,7 @@
     <include file="config/liquibase/changelog/20180528114846_added_entity_Comment.xml" relativeToChangelogFile="false"/>
     <include file="config/liquibase/changelog/20180529124818_added_entity_Activity.xml" relativeToChangelogFile="false"/>
     <include file="config/liquibase/changelog/20180605123508_added_entity_Image.xml" relativeToChangelogFile="false"/>
+    <include file="config/liquibase/changelog/20190121142418_added_entity_Training.xml" relativeToChangelogFile="false"/>
     <!-- jhipster-needle-liquibase-add-changelog - JHipster will add liquibase changelogs here -->
     <include file="config/liquibase/changelog/20180419083624_added_entity_constraints_Team.xml" relativeToChangelogFile="false"/>
     <include file="config/liquibase/changelog/20180419092355_added_entity_constraints_TeamSkill.xml" relativeToChangelogFile="false"/>
@@ -26,6 +27,7 @@
     <include file="config/liquibase/changelog/20180419154302_added_entity_constraints_LevelSkill.xml" relativeToChangelogFile="false"/>
     <include file="config/liquibase/changelog/20180419135514_added_entity_constraints_Badge.xml" relativeToChangelogFile="false"/>
     <include file="config/liquibase/changelog/20180528114846_added_entity_constraints_Comment.xml" relativeToChangelogFile="false"/>
+    <include file="config/liquibase/changelog/20190121142418_added_entity_constraints_Training.xml" relativeToChangelogFile="false"/>
     <!-- jhipster-needle-liquibase-add-constraints-changelog - JHipster will add liquibase constraints changelogs here -->
     <include file="config/liquibase/changelog/20180604134444_initial_demo_data.xml" relativeToChangelogFile="false"/>
     <include file="config/liquibase/changelog/20180612164700_extend_skill_descriptions_length.xml" relativeToChangelogFile="false"/>

--- a/src/main/resources/config/liquibase/master.xml
+++ b/src/main/resources/config/liquibase/master.xml
@@ -18,7 +18,7 @@
     <include file="config/liquibase/changelog/20180528114846_added_entity_Comment.xml" relativeToChangelogFile="false"/>
     <include file="config/liquibase/changelog/20180529124818_added_entity_Activity.xml" relativeToChangelogFile="false"/>
     <include file="config/liquibase/changelog/20180605123508_added_entity_Image.xml" relativeToChangelogFile="false"/>
-    <include file="config/liquibase/changelog/20190121142418_added_entity_Training.xml" relativeToChangelogFile="false"/>
+    <include file="config/liquibase/changelog/20190122103014_added_entity_Training.xml" relativeToChangelogFile="false"/>
     <!-- jhipster-needle-liquibase-add-changelog - JHipster will add liquibase changelogs here -->
     <include file="config/liquibase/changelog/20180419083624_added_entity_constraints_Team.xml" relativeToChangelogFile="false"/>
     <include file="config/liquibase/changelog/20180419092355_added_entity_constraints_TeamSkill.xml" relativeToChangelogFile="false"/>
@@ -27,7 +27,7 @@
     <include file="config/liquibase/changelog/20180419154302_added_entity_constraints_LevelSkill.xml" relativeToChangelogFile="false"/>
     <include file="config/liquibase/changelog/20180419135514_added_entity_constraints_Badge.xml" relativeToChangelogFile="false"/>
     <include file="config/liquibase/changelog/20180528114846_added_entity_constraints_Comment.xml" relativeToChangelogFile="false"/>
-    <include file="config/liquibase/changelog/20190121142418_added_entity_constraints_Training.xml" relativeToChangelogFile="false"/>
+    <include file="config/liquibase/changelog/20190122103014_added_entity_constraints_Training.xml" relativeToChangelogFile="false"/>
     <!-- jhipster-needle-liquibase-add-constraints-changelog - JHipster will add liquibase constraints changelogs here -->
     <include file="config/liquibase/changelog/20180604134444_initial_demo_data.xml" relativeToChangelogFile="false"/>
     <include file="config/liquibase/changelog/20180612164700_extend_skill_descriptions_length.xml" relativeToChangelogFile="false"/>

--- a/src/main/webapp/app/entities/entity.module.ts
+++ b/src/main/webapp/app/entities/entity.module.ts
@@ -13,6 +13,7 @@ import { TeamdojoReportModule } from './report/report.module';
 import { TeamdojoCommentModule } from './comment/comment.module';
 import { TeamdojoActivityModule } from './activity/activity.module';
 import { TeamdojoImageModule } from './image/image.module';
+import { TeamdojoTrainingModule } from './training/training.module';
 /* jhipster-needle-add-entity-module-import - JHipster will add entity modules imports here */
 
 @NgModule({
@@ -31,6 +32,7 @@ import { TeamdojoImageModule } from './image/image.module';
         TeamdojoCommentModule,
         TeamdojoActivityModule,
         TeamdojoImageModule,
+        TeamdojoTrainingModule,
         /* jhipster-needle-add-entity-module - JHipster will add entity modules here */
     ],
     declarations: [],

--- a/src/main/webapp/app/entities/skill/skill-update.component.ts
+++ b/src/main/webapp/app/entities/skill/skill-update.component.ts
@@ -2,9 +2,12 @@ import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { HttpResponse, HttpErrorResponse } from '@angular/common/http';
 import { Observable } from 'rxjs/Observable';
+import { JhiAlertService } from 'ng-jhipster';
 
 import { ISkill } from 'app/shared/model/skill.model';
 import { SkillService } from './skill.service';
+import { ITraining } from 'app/shared/model/training.model';
+import { TrainingService } from 'app/entities/training';
 
 @Component({
     selector: 'jhi-skill-update',
@@ -14,13 +17,26 @@ export class SkillUpdateComponent implements OnInit {
     private _skill: ISkill;
     isSaving: boolean;
 
-    constructor(private skillService: SkillService, private route: ActivatedRoute) {}
+    trainings: ITraining[];
+
+    constructor(
+        private jhiAlertService: JhiAlertService,
+        private skillService: SkillService,
+        private trainingService: TrainingService,
+        private route: ActivatedRoute
+    ) {}
 
     ngOnInit() {
         this.isSaving = false;
         this.route.data.subscribe(({ skill }) => {
             this.skill = skill.body ? skill.body : skill;
         });
+        this.trainingService.query().subscribe(
+            (res: HttpResponse<ITraining[]>) => {
+                this.trainings = res.body;
+            },
+            (res: HttpErrorResponse) => this.onError(res.message)
+        );
     }
 
     previousState() {
@@ -47,6 +63,25 @@ export class SkillUpdateComponent implements OnInit {
 
     private onSaveError() {
         this.isSaving = false;
+    }
+
+    private onError(errorMessage: string) {
+        this.jhiAlertService.error(errorMessage, null, null);
+    }
+
+    trackTrainingById(index: number, item: ITraining) {
+        return item.id;
+    }
+
+    getSelected(selectedVals: Array<any>, option: any) {
+        if (selectedVals) {
+            for (let i = 0; i < selectedVals.length; i++) {
+                if (option.id === selectedVals[i].id) {
+                    return selectedVals[i];
+                }
+            }
+        }
+        return option;
     }
     get skill() {
         return this._skill;

--- a/src/main/webapp/app/entities/training/index.ts
+++ b/src/main/webapp/app/entities/training/index.ts
@@ -1,0 +1,6 @@
+export * from './training.service';
+export * from './training-update.component';
+export * from './training-delete-dialog.component';
+export * from './training-detail.component';
+export * from './training.component';
+export * from './training.route';

--- a/src/main/webapp/app/entities/training/training-delete-dialog.component.html
+++ b/src/main/webapp/app/entities/training/training-delete-dialog.component.html
@@ -1,0 +1,19 @@
+<form name="deleteForm" (ngSubmit)="confirmDelete(training.id)">
+    <div class="modal-header">
+        <h4 class="modal-title" jhiTranslate="entity.delete.title">Confirm delete operation</h4>
+        <button type="button" class="close" data-dismiss="modal" aria-hidden="true"
+                (click)="clear()">&times;</button>
+    </div>
+    <div class="modal-body">
+        <jhi-alert-error></jhi-alert-error>
+        <p jhiTranslate="teamdojoApp.training.delete.question" translateValues="{id: '{{training.id}}'}">Are you sure you want to delete this Training?</p>
+    </div>
+    <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-dismiss="modal" (click)="clear()">
+            <span class="fa fa-ban"></span>&nbsp;<span jhiTranslate="entity.action.cancel">Cancel</span>
+        </button>
+        <button type="submit" class="btn btn-danger">
+            <span class="fa fa-remove"></span>&nbsp;<span jhiTranslate="entity.action.delete">Delete</span>
+        </button>
+    </div>
+</form>

--- a/src/main/webapp/app/entities/training/training-delete-dialog.component.ts
+++ b/src/main/webapp/app/entities/training/training-delete-dialog.component.ts
@@ -1,0 +1,65 @@
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+
+import { NgbActiveModal, NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
+import { JhiEventManager } from 'ng-jhipster';
+
+import { ITraining } from 'app/shared/model/training.model';
+import { TrainingService } from './training.service';
+
+@Component({
+    selector: 'jhi-training-delete-dialog',
+    templateUrl: './training-delete-dialog.component.html'
+})
+export class TrainingDeleteDialogComponent {
+    training: ITraining;
+
+    constructor(private trainingService: TrainingService, public activeModal: NgbActiveModal, private eventManager: JhiEventManager) {}
+
+    clear() {
+        this.activeModal.dismiss('cancel');
+    }
+
+    confirmDelete(id: number) {
+        this.trainingService.delete(id).subscribe(response => {
+            this.eventManager.broadcast({
+                name: 'trainingListModification',
+                content: 'Deleted an training'
+            });
+            this.activeModal.dismiss(true);
+        });
+    }
+}
+
+@Component({
+    selector: 'jhi-training-delete-popup',
+    template: ''
+})
+export class TrainingDeletePopupComponent implements OnInit, OnDestroy {
+    private ngbModalRef: NgbModalRef;
+
+    constructor(private route: ActivatedRoute, private router: Router, private modalService: NgbModal) {}
+
+    ngOnInit() {
+        this.route.data.subscribe(({ training }) => {
+            setTimeout(() => {
+                this.ngbModalRef = this.modalService.open(TrainingDeleteDialogComponent as Component, { size: 'lg', backdrop: 'static' });
+                this.ngbModalRef.componentInstance.training = training.body;
+                this.ngbModalRef.result.then(
+                    result => {
+                        this.router.navigate([{ outlets: { popup: null } }], { replaceUrl: true, queryParamsHandling: 'merge' });
+                        this.ngbModalRef = null;
+                    },
+                    reason => {
+                        this.router.navigate([{ outlets: { popup: null } }], { replaceUrl: true, queryParamsHandling: 'merge' });
+                        this.ngbModalRef = null;
+                    }
+                );
+            }, 0);
+        });
+    }
+
+    ngOnDestroy() {
+        this.ngbModalRef = null;
+    }
+}

--- a/src/main/webapp/app/entities/training/training-detail.component.html
+++ b/src/main/webapp/app/entities/training/training-detail.component.html
@@ -1,0 +1,53 @@
+<div class="row justify-content-center">
+    <div class="col-8">
+        <div *ngIf="training">
+            <h2><span jhiTranslate="teamdojoApp.training.detail.title">Training</span> {{training.id}}</h2>
+            <hr>
+            <jhi-alert-error></jhi-alert-error>
+            <dl class="row-md jh-entity-details">
+                <dt><span jhiTranslate="teamdojoApp.training.title">Title</span></dt>
+                <dd>
+                    <span>{{training.title}}</span>
+                </dd>
+                <dt><span jhiTranslate="teamdojoApp.training.description">Description</span></dt>
+                <dd>
+                    <span>{{training.description}}</span>
+                </dd>
+                <dt><span jhiTranslate="teamdojoApp.training.contactPerson">Contact Person</span></dt>
+                <dd>
+                    <span>{{training.contactPerson}}</span>
+                </dd>
+                <dt><span jhiTranslate="teamdojoApp.training.link">Link</span></dt>
+                <dd>
+                    <span>{{training.link}}</span>
+                </dd>
+                <dt><span jhiTranslate="teamdojoApp.training.validUntil">Valid Until</span></dt>
+                <dd>
+                    <span>{{training.validUntil}}</span>
+                </dd>
+                <dt><span jhiTranslate="teamdojoApp.training.isOfficial">Is Official</span></dt>
+                <dd>
+                    <span>{{training.isOfficial}}</span>
+                </dd>
+                <dt><span jhiTranslate="teamdojoApp.training.skill">Skill</span></dt>
+                <dd>
+                    <span *ngFor="let skill of training.skills; let last = last">
+                        <a [routerLink]="['/skill', skill?.id, 'view' ]">{{skill.title}}</a>{{last ? '' : ', '}}
+                    </span>
+                </dd>
+            </dl>
+
+            <button type="submit"
+                    (click)="previousState()"
+                    class="btn btn-info">
+                <span class="fa fa-arrow-left"></span>&nbsp;<span jhiTranslate="entity.action.back"> Back</span>
+            </button>
+
+            <button type="button"
+                    [routerLink]="['/training', training.id, 'edit']"
+                    class="btn btn-primary">
+                <span class="fa fa-pencil"></span>&nbsp;<span jhiTranslate="entity.action.edit"> Edit</span>
+            </button>
+        </div>
+    </div>
+</div>

--- a/src/main/webapp/app/entities/training/training-detail.component.ts
+++ b/src/main/webapp/app/entities/training/training-detail.component.ts
@@ -1,0 +1,24 @@
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+
+import { ITraining } from 'app/shared/model/training.model';
+
+@Component({
+    selector: 'jhi-training-detail',
+    templateUrl: './training-detail.component.html'
+})
+export class TrainingDetailComponent implements OnInit {
+    training: ITraining;
+
+    constructor(private route: ActivatedRoute) {}
+
+    ngOnInit() {
+        this.route.data.subscribe(({ training }) => {
+            this.training = training.body ? training.body : training;
+        });
+    }
+
+    previousState() {
+        window.history.back();
+    }
+}

--- a/src/main/webapp/app/entities/training/training-update.component.html
+++ b/src/main/webapp/app/entities/training/training-update.component.html
@@ -50,8 +50,7 @@
                            for="field_validUntil">Valid Until</label>
                     <div class="d-flex">
                         <input id="field_validUntil" type="datetime-local" class="form-control" name="validUntil"
-                               [(ngModel)]="validUntil"
-                        />
+                               [(ngModel)]="validUntil" [placeholder]="'teamdojoApp.training.validUntilPlaceholder' | translate"/>
                     </div>
                 </div>
                 <div class="form-group">

--- a/src/main/webapp/app/entities/training/training-update.component.html
+++ b/src/main/webapp/app/entities/training/training-update.component.html
@@ -38,12 +38,27 @@
                 <div class="form-group">
                     <label class="form-control-label" jhiTranslate="teamdojoApp.training.contactPerson" for="field_contactPerson">Contact Person</label>
                     <input type="text" class="form-control" name="contactPerson" id="field_contactPerson"
-                        [(ngModel)]="training.contactPerson" />
+                           [(ngModel)]="training.contactPerson" maxlength="255"/>
+                    <div
+                        [hidden]="!(editForm.controls.contactPerson?.dirty && editForm.controls.contactPerson?.invalid)">
+                        <small class="form-text text-danger"
+                               [hidden]="!editForm.controls.contactPerson?.errors?.maxlength"
+                               jhiTranslate="entity.validation.maxlength" translateValues="{ max: 255 }">
+                            This field cannot be longer than 255 characters.
+                        </small>
+                    </div>
                 </div>
                 <div class="form-group">
                     <label class="form-control-label" jhiTranslate="teamdojoApp.training.link" for="field_link">Link</label>
                     <input type="text" class="form-control" name="link" id="field_link"
-                        [(ngModel)]="training.link" />
+                           [(ngModel)]="training.link" maxlength="255"/>
+                    <div [hidden]="!(editForm.controls.link?.dirty && editForm.controls.link?.invalid)">
+                        <small class="form-text text-danger"
+                               [hidden]="!editForm.controls.link?.errors?.maxlength"
+                               jhiTranslate="entity.validation.maxlength" translateValues="{ max: 255 }">
+                            This field cannot be longer than 255 characters.
+                        </small>
+                    </div>
                 </div>
                 <div class="form-group">
                     <label class="form-control-label" jhiTranslate="teamdojoApp.training.validUntil"

--- a/src/main/webapp/app/entities/training/training-update.component.html
+++ b/src/main/webapp/app/entities/training/training-update.component.html
@@ -1,0 +1,86 @@
+<div class="row justify-content-center">
+    <div class="col-8">
+        <form name="editForm" role="form" novalidate (ngSubmit)="save()" #editForm="ngForm">
+            <h2 id="jhi-training-heading" jhiTranslate="teamdojoApp.training.home.createOrEditLabel">Create or edit a Training</h2>
+            <div>
+                <jhi-alert-error></jhi-alert-error>
+                <div class="form-group" [hidden]="!training.id">
+                    <label for="id" jhiTranslate="global.field.id">ID</label>
+                    <input type="text" class="form-control" id="id" name="id"
+                        [(ngModel)]="training.id" readonly />
+                </div>
+                <div class="form-group">
+                    <label class="form-control-label" jhiTranslate="teamdojoApp.training.title" for="field_title">Title</label>
+                    <input type="text" class="form-control" name="title" id="field_title"
+                        [(ngModel)]="training.title" required maxlength="80"/>
+                    <div [hidden]="!(editForm.controls.title?.dirty && editForm.controls.title?.invalid)">
+                        <small class="form-text text-danger"
+                        [hidden]="!editForm.controls.title?.errors?.required" jhiTranslate="entity.validation.required">
+                        This field is required.
+                        </small>
+                        <small class="form-text text-danger"
+                        [hidden]="!editForm.controls.title?.errors?.maxlength" jhiTranslate="entity.validation.maxlength" translateValues="{ max: 80 }">
+                        This field cannot be longer than 80 characters.
+                        </small>
+                    </div>
+                </div>
+                <div class="form-group">
+                    <label class="form-control-label" jhiTranslate="teamdojoApp.training.description" for="field_description">Description</label>
+                    <input type="text" class="form-control" name="description" id="field_description"
+                        [(ngModel)]="training.description" maxlength="100"/>
+                    <div [hidden]="!(editForm.controls.description?.dirty && editForm.controls.description?.invalid)">
+                        <small class="form-text text-danger"
+                        [hidden]="!editForm.controls.description?.errors?.maxlength" jhiTranslate="entity.validation.maxlength" translateValues="{ max: 100 }">
+                        This field cannot be longer than 100 characters.
+                        </small>
+                    </div>
+                </div>
+                <div class="form-group">
+                    <label class="form-control-label" jhiTranslate="teamdojoApp.training.contactPerson" for="field_contactPerson">Contact Person</label>
+                    <input type="text" class="form-control" name="contactPerson" id="field_contactPerson"
+                        [(ngModel)]="training.contactPerson" />
+                </div>
+                <div class="form-group">
+                    <label class="form-control-label" jhiTranslate="teamdojoApp.training.link" for="field_link">Link</label>
+                    <input type="text" class="form-control" name="link" id="field_link"
+                        [(ngModel)]="training.link" />
+                </div>
+                <div class="form-group">
+                    <label class="form-control-label" jhiTranslate="teamdojoApp.training.validUntil"
+                           for="field_validUntil">Valid Until</label>
+                    <div class="d-flex">
+                        <input id="field_validUntil" type="datetime-local" class="form-control" name="validUntil"
+                               [(ngModel)]="validUntil"
+                        />
+                    </div>
+                </div>
+                <div class="form-group">
+                    <label class="form-control-label" jhiTranslate="teamdojoApp.training.isOfficial" for="field_isOfficial">Is Official</label>
+                    <input type="checkbox" class="form-control" name="isOfficial" id="field_isOfficial"
+                        [(ngModel)]="training.isOfficial" />
+                    <div [hidden]="!(editForm.controls.isOfficial?.dirty && editForm.controls.isOfficial?.invalid)">
+                        <small class="form-text text-danger"
+                        [hidden]="!editForm.controls.isOfficial?.errors?.required" jhiTranslate="entity.validation.required">
+                        This field is required.
+                        </small>
+                    </div>
+                </div>
+
+                <div class="form-group">
+                    <label jhiTranslate="teamdojoApp.training.skill" for="field_skill">Skill</label>
+                    <select class="form-control" id="field_skill" multiple name="skill" [(ngModel)]="training.skills">
+                        <option [ngValue]="getSelected(training.skills, skillOption)" *ngFor="let skillOption of skills; trackBy: trackSkillById">{{skillOption.title}}</option>
+                    </select>
+                </div>
+            </div>
+            <div>
+                <button type="button" id="cancel-save" class="btn btn-secondary"  (click)="previousState()">
+                    <span class="fa fa-ban"></span>&nbsp;<span jhiTranslate="entity.action.cancel">Cancel</span>
+                </button>
+                <button type="submit" id="save-entity" [disabled]="editForm.form.invalid || isSaving" class="btn btn-primary">
+                    <span class="fa fa-save"></span>&nbsp;<span jhiTranslate="entity.action.save">Save</span>
+                </button>
+            </div>
+        </form>
+    </div>
+</div>

--- a/src/main/webapp/app/entities/training/training-update.component.html
+++ b/src/main/webapp/app/entities/training/training-update.component.html
@@ -51,12 +51,18 @@
                 <div class="form-group">
                     <label class="form-control-label" jhiTranslate="teamdojoApp.training.link" for="field_link">Link</label>
                     <input type="text" class="form-control" name="link" id="field_link"
-                           [(ngModel)]="training.link" maxlength="255"/>
+                           [(ngModel)]="training.link" maxlength="255"
+                           pattern="^(?:http(s)?://)?[\w.-]+(?:\.[\w\.-]+)+[\w\-\._~:/?#\[\]@!\$&'\(\)\*\+,;=.]+$"/>
                     <div [hidden]="!(editForm.controls.link?.dirty && editForm.controls.link?.invalid)">
                         <small class="form-text text-danger"
                                [hidden]="!editForm.controls.link?.errors?.maxlength"
                                jhiTranslate="entity.validation.maxlength" translateValues="{ max: 255 }">
                             This field cannot be longer than 255 characters.
+                        </small>
+                        <small class="form-text text-danger"
+                               [hidden]="!editForm.controls.link?.errors?.pattern"
+                               jhiTranslate="entity.validation.pattern" translateValues="{ pattern: 'Link' }">
+                            This field should follow pattern for "Link".
                         </small>
                     </div>
                 </div>

--- a/src/main/webapp/app/entities/training/training-update.component.html
+++ b/src/main/webapp/app/entities/training/training-update.component.html
@@ -64,6 +64,11 @@
                                jhiTranslate="entity.validation.pattern" translateValues="{ pattern: 'Link' }">
                             This field should follow pattern for "Link".
                         </small>
+                        <small class="form-text text-danger"
+                               [hidden]="!editForm.controls.link?.errors?.pattern" jhiTranslate="entity.validation.expectedPattern"
+                               [translateValues]="{ regex: '/^(?:http(s)?:\/\/)?[\\w.-]+(?:\\.[\\w\\.-]+)+[\\w\\-\\._~:\/?#\\[\\]@!\\$&\'\\(\\)\\*\\+,;=.]+$/' }">
+                            The expected pattern is /^(?:http(s)?:\/\/)?[\w.-]+(?:\.[\w\.-]+)+[\w\-\._~:\/?#\[\]@!\$&\'\(\)\*\+,;=.]+$/.
+                        </small>
                     </div>
                 </div>
                 <div class="form-group">

--- a/src/main/webapp/app/entities/training/training-update.component.ts
+++ b/src/main/webapp/app/entities/training/training-update.component.ts
@@ -33,6 +33,9 @@ export class TrainingUpdateComponent implements OnInit {
         this.isSaving = false;
         this.route.data.subscribe(({ training }) => {
             this.training = training.body ? training.body : training;
+            if (!this.training.id) {
+                this.training.isOfficial = true;
+            }
         });
         this.skillService.query().subscribe(
             (res: HttpResponse<ISkill[]>) => {

--- a/src/main/webapp/app/entities/training/training-update.component.ts
+++ b/src/main/webapp/app/entities/training/training-update.component.ts
@@ -96,6 +96,6 @@ export class TrainingUpdateComponent implements OnInit {
 
     set training(training: ITraining) {
         this._training = training;
-        this.validUntil = moment(training.validUntil).format();
+        this.validUntil = training.validUntil ? moment(training.validUntil).format() : undefined;
     }
 }

--- a/src/main/webapp/app/entities/training/training-update.component.ts
+++ b/src/main/webapp/app/entities/training/training-update.component.ts
@@ -1,0 +1,98 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { HttpResponse, HttpErrorResponse } from '@angular/common/http';
+import { Observable } from 'rxjs/Observable';
+import * as moment from 'moment';
+import { DATE_TIME_FORMAT } from 'app/shared/constants/input.constants';
+import { JhiAlertService } from 'ng-jhipster';
+
+import { ITraining } from 'app/shared/model/training.model';
+import { TrainingService } from './training.service';
+import { ISkill } from 'app/shared/model/skill.model';
+import { SkillService } from 'app/entities/skill';
+
+@Component({
+    selector: 'jhi-training-update',
+    templateUrl: './training-update.component.html'
+})
+export class TrainingUpdateComponent implements OnInit {
+    private _training: ITraining;
+    isSaving: boolean;
+
+    skills: ISkill[];
+    validUntil: string;
+
+    constructor(
+        private jhiAlertService: JhiAlertService,
+        private trainingService: TrainingService,
+        private skillService: SkillService,
+        private route: ActivatedRoute
+    ) {}
+
+    ngOnInit() {
+        this.isSaving = false;
+        this.route.data.subscribe(({ training }) => {
+            this.training = training.body ? training.body : training;
+        });
+        this.skillService.query().subscribe(
+            (res: HttpResponse<ISkill[]>) => {
+                this.skills = res.body;
+            },
+            (res: HttpErrorResponse) => this.onError(res.message)
+        );
+    }
+
+    previousState() {
+        window.history.back();
+    }
+
+    save() {
+        this.isSaving = true;
+        this.training.validUntil = moment(this.validUntil, DATE_TIME_FORMAT);
+        if (this.training.id !== undefined) {
+            this.subscribeToSaveResponse(this.trainingService.update(this.training));
+        } else {
+            this.subscribeToSaveResponse(this.trainingService.create(this.training));
+        }
+    }
+
+    private subscribeToSaveResponse(result: Observable<HttpResponse<ITraining>>) {
+        result.subscribe((res: HttpResponse<ITraining>) => this.onSaveSuccess(res.body), (res: HttpErrorResponse) => this.onSaveError());
+    }
+
+    private onSaveSuccess(result: ITraining) {
+        this.isSaving = false;
+        this.previousState();
+    }
+
+    private onSaveError() {
+        this.isSaving = false;
+    }
+
+    private onError(errorMessage: string) {
+        this.jhiAlertService.error(errorMessage, null, null);
+    }
+
+    trackSkillById(index: number, item: ISkill) {
+        return item.id;
+    }
+
+    getSelected(selectedVals: Array<any>, option: any) {
+        if (selectedVals) {
+            for (let i = 0; i < selectedVals.length; i++) {
+                if (option.id === selectedVals[i].id) {
+                    return selectedVals[i];
+                }
+            }
+        }
+        return option;
+    }
+    get training() {
+        return this._training;
+    }
+
+    set training(training: ITraining) {
+        this._training = training;
+        this.validUntil = moment(training.validUntil).format();
+    }
+}

--- a/src/main/webapp/app/entities/training/training.component.html
+++ b/src/main/webapp/app/entities/training/training.component.html
@@ -1,0 +1,65 @@
+<div>
+    <h2 id="page-heading">
+        <span jhiTranslate="teamdojoApp.training.home.title">Trainings</span>
+        <button id="jh-create-entity" class="btn btn-primary float-right jh-create-entity create-training" [routerLink]="['/training/new']">
+            <span class="fa fa-plus"></span>
+            <span  jhiTranslate="teamdojoApp.training.home.createLabel">
+            Create new Training
+            </span>
+        </button>
+    </h2>
+    <jhi-alert></jhi-alert>
+    <br/>
+    <div class="table-responsive" *ngIf="trainings">
+        <table class="table table-striped">
+            <thead>
+            <tr jhiSort [(predicate)]="predicate" [(ascending)]="reverse" [callback]="reset.bind(this)">
+            <th jhiSortBy="id"><span jhiTranslate="global.field.id">ID</span> <span class="fa fa-sort"></span></th>
+            <th jhiSortBy="title"><span jhiTranslate="teamdojoApp.training.title">Title</span> <span class="fa fa-sort"></span></th>
+            <th jhiSortBy="description"><span jhiTranslate="teamdojoApp.training.description">Description</span> <span class="fa fa-sort"></span></th>
+            <th jhiSortBy="contactPerson"><span jhiTranslate="teamdojoApp.training.contactPerson">Contact Person</span> <span class="fa fa-sort"></span></th>
+            <th jhiSortBy="link"><span jhiTranslate="teamdojoApp.training.link">Link</span> <span class="fa fa-sort"></span></th>
+                <th jhiSortBy="validUntil"><span jhiTranslate="teamdojoApp.training.validUntil">Valid Until</span> <span
+                    class="fa fa-sort"></span></th>
+            <th jhiSortBy="isOfficial"><span jhiTranslate="teamdojoApp.training.isOfficial">Is Official</span> <span class="fa fa-sort"></span></th>
+            <th></th>
+            </tr>
+            </thead>
+            <tbody infinite-scroll (scrolled)="loadPage(page + 1)" [infiniteScrollDisabled]="page >= links['last']" [infiniteScrollDistance]="0">
+            <tr *ngFor="let training of trainings ;trackBy: trackId">
+                <td><a [routerLink]="['/training', training.id, 'view' ]">{{training.id}}</a></td>
+                <td>{{training.title}}</td>
+                <td>{{training.description}}</td>
+                <td>{{training.contactPerson}}</td>
+                <td>{{training.link}}</td>
+                <td>{{training.validUntil | date:'medium'}}</td>
+                <td>{{training.isOfficial}}</td>
+                <td class="text-right">
+                    <div class="btn-group flex-btn-group-container">
+                        <button type="submit"
+                                [routerLink]="['/training', training.id, 'view' ]"
+                                class="btn btn-info btn-sm">
+                            <span class="fa fa-eye"></span>
+                            <span class="d-none d-md-inline" jhiTranslate="entity.action.view">View</span>
+                        </button>
+                        <button type="submit"
+                                [routerLink]="['/training', training.id, 'edit']"
+                                class="btn btn-primary btn-sm">
+                            <span class="fa fa-pencil"></span>
+                            <span class="d-none d-md-inline" jhiTranslate="entity.action.edit">Edit</span>
+                        </button>
+                        <button type="submit"
+                                [routerLink]="['/', { outlets: { popup: 'training/'+ training.id + '/delete'} }]"
+                                replaceUrl="true"
+                                queryParamsHandling="merge"
+                                class="btn btn-danger btn-sm">
+                            <span class="fa fa-remove"></span>
+                            <span class="d-none d-md-inline" jhiTranslate="entity.action.delete">Delete</span>
+                        </button>
+                    </div>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+</div>

--- a/src/main/webapp/app/entities/training/training.component.ts
+++ b/src/main/webapp/app/entities/training/training.component.ts
@@ -1,0 +1,108 @@
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { HttpErrorResponse, HttpHeaders, HttpResponse } from '@angular/common/http';
+import { Subscription } from 'rxjs/Subscription';
+import { JhiEventManager, JhiParseLinks, JhiAlertService } from 'ng-jhipster';
+
+import { ITraining } from 'app/shared/model/training.model';
+import { Principal } from 'app/core';
+
+import { ITEMS_PER_PAGE } from 'app/shared';
+import { TrainingService } from './training.service';
+
+@Component({
+    selector: 'jhi-training',
+    templateUrl: './training.component.html'
+})
+export class TrainingComponent implements OnInit, OnDestroy {
+    trainings: ITraining[];
+    currentAccount: any;
+    eventSubscriber: Subscription;
+    itemsPerPage: number;
+    links: any;
+    page: any;
+    predicate: any;
+    queryCount: any;
+    reverse: any;
+    totalItems: number;
+
+    constructor(
+        private trainingService: TrainingService,
+        private jhiAlertService: JhiAlertService,
+        private eventManager: JhiEventManager,
+        private parseLinks: JhiParseLinks,
+        private principal: Principal
+    ) {
+        this.trainings = [];
+        this.itemsPerPage = ITEMS_PER_PAGE;
+        this.page = 0;
+        this.links = {
+            last: 0
+        };
+        this.predicate = 'id';
+        this.reverse = true;
+    }
+
+    loadAll() {
+        this.trainingService
+            .query({
+                page: this.page,
+                size: this.itemsPerPage,
+                sort: this.sort()
+            })
+            .subscribe(
+                (res: HttpResponse<ITraining[]>) => this.paginateTrainings(res.body, res.headers),
+                (res: HttpErrorResponse) => this.onError(res.message)
+            );
+    }
+
+    reset() {
+        this.page = 0;
+        this.trainings = [];
+        this.loadAll();
+    }
+
+    loadPage(page) {
+        this.page = page;
+        this.loadAll();
+    }
+
+    ngOnInit() {
+        this.loadAll();
+        this.principal.identity().then(account => {
+            this.currentAccount = account;
+        });
+        this.registerChangeInTrainings();
+    }
+
+    ngOnDestroy() {
+        this.eventManager.destroy(this.eventSubscriber);
+    }
+
+    trackId(index: number, item: ITraining) {
+        return item.id;
+    }
+
+    registerChangeInTrainings() {
+        this.eventSubscriber = this.eventManager.subscribe('trainingListModification', response => this.reset());
+    }
+
+    sort() {
+        const result = [this.predicate + ',' + (this.reverse ? 'asc' : 'desc')];
+        if (this.predicate !== 'id') {
+            result.push('id');
+        }
+        return result;
+    }
+
+    private paginateTrainings(data: ITraining[], headers: HttpHeaders) {
+        this.links = this.parseLinks.parse(headers.get('link'));
+        this.totalItems = parseInt(headers.get('X-Total-Count'), 10);
+        for (let i = 0; i < data.length; i++) {
+            this.trainings.push(data[i]);
+        }
+    }
+
+    private onError(errorMessage: string) {
+        this.jhiAlertService.error(errorMessage, null, null);
+    }
+}

--- a/src/main/webapp/app/entities/training/training.module.ts
+++ b/src/main/webapp/app/entities/training/training.module.ts
@@ -1,0 +1,32 @@
+import { NgModule, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { RouterModule } from '@angular/router';
+
+import { TeamdojoSharedModule } from 'app/shared';
+import {
+    TrainingService,
+    TrainingComponent,
+    TrainingDetailComponent,
+    TrainingUpdateComponent,
+    TrainingDeletePopupComponent,
+    TrainingDeleteDialogComponent,
+    trainingRoute,
+    trainingPopupRoute,
+    TrainingResolve
+} from './';
+
+const ENTITY_STATES = [...trainingRoute, ...trainingPopupRoute];
+
+@NgModule({
+    imports: [TeamdojoSharedModule, RouterModule.forChild(ENTITY_STATES)],
+    declarations: [
+        TrainingComponent,
+        TrainingDetailComponent,
+        TrainingUpdateComponent,
+        TrainingDeleteDialogComponent,
+        TrainingDeletePopupComponent
+    ],
+    entryComponents: [TrainingComponent, TrainingUpdateComponent, TrainingDeleteDialogComponent, TrainingDeletePopupComponent],
+    providers: [TrainingService, TrainingResolve],
+    schemas: [CUSTOM_ELEMENTS_SCHEMA]
+})
+export class TeamdojoTrainingModule {}

--- a/src/main/webapp/app/entities/training/training.route.ts
+++ b/src/main/webapp/app/entities/training/training.route.ts
@@ -1,0 +1,87 @@
+import { Injectable } from '@angular/core';
+import { Resolve, ActivatedRouteSnapshot, RouterStateSnapshot, Routes } from '@angular/router';
+
+import { UserRouteAccessService } from 'app/core';
+import { Training } from 'app/shared/model/training.model';
+import { TrainingService } from './training.service';
+import { TrainingComponent } from './training.component';
+import { TrainingDetailComponent } from './training-detail.component';
+import { TrainingUpdateComponent } from './training-update.component';
+import { TrainingDeletePopupComponent } from './training-delete-dialog.component';
+
+@Injectable()
+export class TrainingResolve implements Resolve<any> {
+    constructor(private service: TrainingService) {}
+
+    resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
+        const id = route.params['id'] ? route.params['id'] : null;
+        if (id) {
+            return this.service.find(id);
+        }
+        return new Training();
+    }
+}
+
+export const trainingRoute: Routes = [
+    {
+        path: 'training',
+        component: TrainingComponent,
+        data: {
+            authorities: ['ROLE_USER'],
+            pageTitle: 'teamdojoApp.training.home.title'
+        },
+        canActivate: [UserRouteAccessService]
+    },
+    {
+        path: 'training/:id/view',
+        component: TrainingDetailComponent,
+        resolve: {
+            training: TrainingResolve
+        },
+        data: {
+            authorities: ['ROLE_USER'],
+            pageTitle: 'teamdojoApp.training.home.title'
+        },
+        canActivate: [UserRouteAccessService]
+    },
+    {
+        path: 'training/new',
+        component: TrainingUpdateComponent,
+        resolve: {
+            training: TrainingResolve
+        },
+        data: {
+            authorities: ['ROLE_USER'],
+            pageTitle: 'teamdojoApp.training.home.title'
+        },
+        canActivate: [UserRouteAccessService]
+    },
+    {
+        path: 'training/:id/edit',
+        component: TrainingUpdateComponent,
+        resolve: {
+            training: TrainingResolve
+        },
+        data: {
+            authorities: ['ROLE_USER'],
+            pageTitle: 'teamdojoApp.training.home.title'
+        },
+        canActivate: [UserRouteAccessService]
+    }
+];
+
+export const trainingPopupRoute: Routes = [
+    {
+        path: 'training/:id/delete',
+        component: TrainingDeletePopupComponent,
+        resolve: {
+            training: TrainingResolve
+        },
+        data: {
+            authorities: ['ROLE_USER'],
+            pageTitle: 'teamdojoApp.training.home.title'
+        },
+        canActivate: [UserRouteAccessService],
+        outlet: 'popup'
+    }
+];

--- a/src/main/webapp/app/entities/training/training.service.ts
+++ b/src/main/webapp/app/entities/training/training.service.ts
@@ -1,0 +1,83 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpResponse } from '@angular/common/http';
+import { Observable } from 'rxjs/Observable';
+import * as moment from 'moment';
+
+import { SERVER_API_URL } from 'app/app.constants';
+import { createRequestOption } from 'app/shared';
+import { ITraining } from 'app/shared/model/training.model';
+
+export type EntityResponseType = HttpResponse<ITraining>;
+export type EntityArrayResponseType = HttpResponse<ITraining[]>;
+
+@Injectable()
+export class TrainingService {
+    private resourceUrl = SERVER_API_URL + 'api/trainings';
+
+    constructor(private http: HttpClient) {}
+
+    create(training: ITraining): Observable<EntityResponseType> {
+        const copy = this.convert(training);
+        return this.http
+            .post<ITraining>(this.resourceUrl, copy, { observe: 'response' })
+            .map((res: EntityResponseType) => this.convertResponse(res));
+    }
+
+    update(training: ITraining): Observable<EntityResponseType> {
+        const copy = this.convert(training);
+        return this.http
+            .put<ITraining>(this.resourceUrl, copy, { observe: 'response' })
+            .map((res: EntityResponseType) => this.convertResponse(res));
+    }
+
+    find(id: number): Observable<EntityResponseType> {
+        return this.http
+            .get<ITraining>(`${this.resourceUrl}/${id}`, { observe: 'response' })
+            .map((res: EntityResponseType) => this.convertResponse(res));
+    }
+
+    query(req?: any): Observable<EntityArrayResponseType> {
+        const options = createRequestOption(req);
+        return this.http
+            .get<ITraining[]>(this.resourceUrl, { params: options, observe: 'response' })
+            .map((res: EntityArrayResponseType) => this.convertArrayResponse(res));
+    }
+
+    delete(id: number): Observable<HttpResponse<any>> {
+        return this.http.delete<any>(`${this.resourceUrl}/${id}`, { observe: 'response' });
+    }
+
+    private convertResponse(res: EntityResponseType): EntityResponseType {
+        const body: ITraining = this.convertItemFromServer(res.body);
+        return res.clone({ body });
+    }
+
+    private convertArrayResponse(res: EntityArrayResponseType): EntityArrayResponseType {
+        const jsonResponse: ITraining[] = res.body;
+        const body: ITraining[] = [];
+        for (let i = 0; i < jsonResponse.length; i++) {
+            body.push(this.convertItemFromServer(jsonResponse[i]));
+        }
+        return res.clone({ body });
+    }
+
+    /**
+     * Convert a returned JSON object to Training.
+     */
+    private convertItemFromServer(training: ITraining): ITraining {
+        const copy: ITraining = Object.assign({}, training, {
+            validUntil: training.validUntil != null ? moment(training.validUntil) : training.validUntil
+        });
+        return copy;
+    }
+
+    /**
+     * Convert a Training to a JSON which can be sent to the server.
+     */
+    private convert(training: ITraining): ITraining {
+        const copy: ITraining = Object.assign({}, training, {
+            validUntil: training.validUntil != null && training.validUntil.isValid() ? training.validUntil.toJSON() : null
+        });
+        return copy;
+    }
+}

--- a/src/main/webapp/app/layouts/navbar/navbar.component.html
+++ b/src/main/webapp/app/layouts/navbar/navbar.component.html
@@ -165,6 +165,12 @@
                             <span jhiTranslate="global.menu.entities.image">Image</span>
                         </a>
                     </li>
+                    <li>
+                        <a class="dropdown-item" routerLink="training" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }" (click)="collapseNavbar()">
+                            <i class="fa fa-fw fa-asterisk" aria-hidden="true"></i>
+                            <span jhiTranslate="global.menu.entities.training">Training</span>
+                        </a>
+                    </li>
                     <!-- jhipster-needle-add-entity-to-menu - JHipster will add entities to the menu here -->
                 </ul>
             </li>

--- a/src/main/webapp/app/overview/overview.module.ts
+++ b/src/main/webapp/app/overview/overview.module.ts
@@ -10,7 +10,7 @@ import { OverviewSkillsComponent } from 'app/overview/skills/overview-skills.com
 import { OverviewSkillDetailsComponent } from 'app/overview/skills/skill-details/overview-skill-details.component';
 import { TeamsModule } from 'app/teams';
 import { BreadcrumbService } from 'app/layouts/navbar/breadcrumb.service';
-import { AllCommentsResolve, AllSkillsResolve, DojoModelResolve, SkillResolve } from 'app/shared/common.resolver';
+import { AllCommentsResolve, AllSkillsResolve, AllTrainingsResolve, DojoModelResolve, SkillResolve } from 'app/shared/common.resolver';
 
 @NgModule({
     imports: [TeamdojoSharedModule, RouterModule.forChild(OVERVIEW_ROUTE), NgbModule, TeamsModule],
@@ -22,7 +22,7 @@ import { AllCommentsResolve, AllSkillsResolve, DojoModelResolve, SkillResolve } 
         OverviewSkillDetailsComponent
     ],
     entryComponents: [],
-    providers: [DojoModelResolve, SkillResolve, AllSkillsResolve, AllCommentsResolve, BreadcrumbService],
+    providers: [DojoModelResolve, SkillResolve, AllSkillsResolve, AllCommentsResolve, AllTrainingsResolve, BreadcrumbService],
     schemas: [CUSTOM_ELEMENTS_SCHEMA]
 })
 export class OverviewModule {}

--- a/src/main/webapp/app/overview/overview.route.ts
+++ b/src/main/webapp/app/overview/overview.route.ts
@@ -2,7 +2,7 @@ import { Route } from '@angular/router';
 import { OverviewComponent } from './';
 import { OverviewSkillDetailsComponent } from 'app/overview/skills/skill-details/overview-skill-details.component';
 import { TeamsSelectionResolve } from 'app/shared/teams-selection/teams-selection.resolve';
-import { AllCommentsResolve, AllSkillsResolve, DojoModelResolve, SkillResolve } from 'app/shared/common.resolver';
+import { AllCommentsResolve, AllSkillsResolve, AllTrainingsResolve, DojoModelResolve, SkillResolve } from 'app/shared/common.resolver';
 
 export const OVERVIEW_ROUTE: Route[] = [
     {
@@ -26,7 +26,8 @@ export const OVERVIEW_ROUTE: Route[] = [
             skill: SkillResolve,
             comments: AllCommentsResolve,
             selectedTeam: TeamsSelectionResolve,
-            skills: AllSkillsResolve
+            skills: AllSkillsResolve,
+            trainings: AllTrainingsResolve
         },
         data: {
             authorities: [],

--- a/src/main/webapp/app/shared/common.resolver.ts
+++ b/src/main/webapp/app/shared/common.resolver.ts
@@ -11,7 +11,7 @@ import { Skill } from 'app/shared/model/skill.model';
 import { CommentService } from 'app/entities/comment';
 import { TeamService } from 'app/entities/team';
 import { Injectable } from '@angular/core';
-import { TeamsService } from 'app/teams/teams.service';
+import { TrainingService } from 'app/entities/training';
 
 @Injectable()
 export class AllTeamsResolve implements Resolve<any> {
@@ -180,5 +180,20 @@ export class SkillResolve implements Resolve<any> {
             });
         }
         return new Skill();
+    }
+}
+
+@Injectable()
+export class AllTrainingsResolve implements Resolve<any> {
+    constructor(private trainingService: TrainingService) {}
+
+    resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
+        const skillId = route.params['skillId'] ? route.params['skillId'] : null;
+        if (skillId) {
+            return this.trainingService.query({ 'skillId.equals': skillId }).map(res => {
+                return res.body;
+            });
+        }
+        return this.trainingService.query();
     }
 }

--- a/src/main/webapp/app/shared/model/skill.model.ts
+++ b/src/main/webapp/app/shared/model/skill.model.ts
@@ -2,6 +2,7 @@ import { ITeamSkill } from './team-skill.model';
 import { IBadgeSkill } from './badge-skill.model';
 import { ILevelSkill } from './level-skill.model';
 import { IComment } from 'app/shared/model/comment.model';
+import { ITraining } from './training.model';
 
 export interface ISkill {
     id?: number;
@@ -18,6 +19,7 @@ export interface ISkill {
     badges?: IBadgeSkill[];
     levels?: ILevelSkill[];
     comments?: IComment[];
+    trainings?: ITraining[];
 }
 
 export class Skill implements ISkill {
@@ -29,12 +31,13 @@ export class Skill implements ISkill {
         public validation?: string,
         public expiryPeriod?: string,
         public contact?: string,
+        public score?: number,
         public rateScore?: number,
         public rateCount?: number,
-        public score?: number,
         public teams?: ITeamSkill[],
         public badges?: IBadgeSkill[],
         public levels?: ILevelSkill[],
-        public comments?: IComment[]
+        public comments?: IComment[],
+        public trainings?: ITraining[]
     ) {}
 }

--- a/src/main/webapp/app/shared/model/training.model.ts
+++ b/src/main/webapp/app/shared/model/training.model.ts
@@ -1,0 +1,28 @@
+import { Moment } from 'moment';
+import { ISkill } from './skill.model';
+
+export interface ITraining {
+    id?: number;
+    title?: string;
+    description?: string;
+    contactPerson?: string;
+    link?: string;
+    validUntil?: Moment;
+    isOfficial?: boolean;
+    skills?: ISkill[];
+}
+
+export class Training implements ITraining {
+    constructor(
+        public id?: number,
+        public title?: string,
+        public description?: string,
+        public contactPerson?: string,
+        public link?: string,
+        public validUntil?: Moment,
+        public isOfficial?: boolean,
+        public skills?: ISkill[]
+    ) {
+        this.isOfficial = false;
+    }
+}

--- a/src/main/webapp/app/shared/skill-details/skill-details-info.component.html
+++ b/src/main/webapp/app/shared/skill-details/skill-details-info.component.html
@@ -52,28 +52,44 @@
         <p>{{skill.validation}}</p>
     </div>
 
-    <div class="needed-for">
-        <h5 jhiTranslate="teamdojoApp.teams.skills.details.neededFor"></h5>
-        <div class="needed-for-avatars">
-            <div class="needed-for-levels">
-                <jhi-achievement-item type="item-level" [item]="l" *ngFor="let l of neededForLevels">
-                </jhi-achievement-item>
+    <div class="row skill-metadata">
+        <div class="col-lg-6 col-md-12">
+            <div class="needed-for">
+                <h5 jhiTranslate="teamdojoApp.teams.skills.details.neededFor"></h5>
+                <div class="needed-for-avatars">
+                    <div class="needed-for-levels">
+                        <jhi-achievement-item type="item-level" [item]="l" *ngFor="let l of neededForLevels">
+                        </jhi-achievement-item>
+                    </div>
+                    <div class="needed-for-badges">
+                        <jhi-achievement-item type="item-badge" [item]="b" *ngFor="let b of neededForBadges">
+                        </jhi-achievement-item>
+                    </div>
+                </div>
             </div>
-            <div class="needed-for-badges">
-                <jhi-achievement-item type="item-badge" [item]="b" *ngFor="let b of neededForBadges">
-                </jhi-achievement-item>
+            <div class="achieved-by">
+                <h5 jhiTranslate="teamdojoApp.teams.skills.details.achievedBy"></h5>
+                <div class="achieved-by-teams">
+                    <jhi-team-image *ngFor="let t of achievedByTeams" class="avatar-team" [team]="t" size="7vh"
+                                    imageSize="medium" placement="top" [ngbTooltip]="t.name"></jhi-team-image>
+                    <p *ngIf="achievedByTeams.length === 0"
+                       jhiTranslate="teamdojoApp.teams.skills.details.achievedByNone"></p>
+                </div>
             </div>
         </div>
-    </div>
-
-    <div class="achieved-by">
-        <h5 jhiTranslate="teamdojoApp.teams.skills.details.achievedBy"></h5>
-        <div class="achieved-by-teams">
-            <jhi-team-image *ngFor="let t of achievedByTeams" class="avatar-team" [team]="t" size="8vh"
-                            imageSize="medium" placement="top" [ngbTooltip]="t.name"></jhi-team-image>
-            <p *ngIf="achievedByTeams.length === 0"
-               jhiTranslate="teamdojoApp.teams.skills.details.achievedByNone"></p>
-            <div class="clearfix"></div>
+        <div class="col-lg-6 col-md-12">
+            <h5 *ngIf="trainings.length" jhiTranslate="teamdojoApp.teams.skills.details.trainings"></h5>
+            <h5 *ngIf="!trainings.length" jhiTranslate="teamdojoApp.teams.skills.details.noTrainings"></h5>
+            <div class="available-trainings">
+                <div *ngFor="let training of trainings">
+                    <h6>
+                        <a *ngIf="training.link" [href]="training.link" target="_blank">{{training.title}}</a>
+                        <span *ngIf="!training.link">{{training.title}}</span>
+                        <small>{{training.contactPerson}}</small>
+                    </h6>
+                    <p>{{training.description}}</p>
+                </div>
+            </div>
         </div>
     </div>
 </div>

--- a/src/main/webapp/app/shared/skill-details/skill-details-info.component.ts
+++ b/src/main/webapp/app/shared/skill-details/skill-details-info.component.ts
@@ -15,6 +15,8 @@ import { IBadgeSkill } from 'app/shared/model/badge-skill.model';
 import { ILevelSkill } from 'app/shared/model/level-skill.model';
 import { ITeamSkill } from 'app/shared/model/team-skill.model';
 import { TeamSkillService } from 'app/entities/team-skill';
+import { ITraining } from 'app/shared/model/training.model';
+import { TrainingService } from 'app/entities/training';
 
 @Component({
     selector: 'jhi-skill-details-info',
@@ -48,6 +50,7 @@ export class SkillDetailsInfoComponent implements OnInit, OnChanges {
     private _levelSkills: ILevelSkill[] = [];
     private _badgeSkills: IBadgeSkill[] = [];
     private _teamSkills: ITeamSkill[] = [];
+    private trainings: ITraining[] = [];
 
     constructor(
         private route: ActivatedRoute,
@@ -56,13 +59,14 @@ export class SkillDetailsInfoComponent implements OnInit, OnChanges {
     ) {}
 
     ngOnInit(): void {
-        this.route.data.subscribe(({ dojoModel: { teams, teamSkills, levels, badges, levelSkills, badgeSkills } }) => {
+        this.route.data.subscribe(({ dojoModel: { teams, teamSkills, levels, badges, levelSkills, badgeSkills }, trainings }) => {
             this._levels = (levels && levels.body ? levels.body : levels) || [];
             this._badges = (badges && badges.body ? badges.body : badges) || [];
             this._teams = (teams && teams.body ? teams.body : teams) || [];
             this._levelSkills = (levelSkills && levelSkills.body ? levelSkills.body : levelSkills) || [];
             this._badgeSkills = (badgeSkills && badgeSkills.body ? badgeSkills.body : badgeSkills) || [];
             this._teamSkills = (teamSkills && teamSkills.body ? teamSkills.body : teamSkills) || [];
+            this.trainings = (trainings && trainings.body ? trainings.body : trainings) || [];
             this.loadData();
         });
     }

--- a/src/main/webapp/app/shared/skill-details/skill-details-info.scss
+++ b/src/main/webapp/app/shared/skill-details/skill-details-info.scss
@@ -75,7 +75,7 @@
     @include shadow();
 }
 
-.needed-for {
+.skill-metadata {
     margin-top: 55px;
 }
 

--- a/src/main/webapp/app/shared/skill-details/skill-details-info.scss
+++ b/src/main/webapp/app/shared/skill-details/skill-details-info.scss
@@ -84,12 +84,14 @@
 }
 
 .avatar-team {
+    flex: 0 0 16%;
     box-sizing: border-box;
-    margin: 12px;
+    margin: 2px 0;
 }
 
 .achieved-by-teams, .needed-for-levels, .needed-for-badges {
     display: flex;
+    flex-wrap: wrap;
     > * {
         display: inline-flex;
     }

--- a/src/main/webapp/app/teams/teams.route.ts
+++ b/src/main/webapp/app/teams/teams.route.ts
@@ -7,7 +7,7 @@ import { Injectable } from '@angular/core';
 import { SkillDetailsComponent } from 'app/teams/skill-details/skill-details.component';
 import { TeamSkillService } from 'app/entities/team-skill';
 import { TeamsSelectionResolve } from 'app/shared/teams-selection/teams-selection.resolve';
-import { AllCommentsResolve, AllSkillsResolve, DojoModelResolve, SkillResolve } from 'app/shared/common.resolver';
+import { AllCommentsResolve, AllSkillsResolve, AllTrainingsResolve, DojoModelResolve, SkillResolve } from 'app/shared/common.resolver';
 
 @Injectable()
 export class TeamAndTeamSkillResolve implements Resolve<any> {
@@ -59,7 +59,8 @@ export const TEAMS_ROUTES: Route[] = [
             skill: SkillResolve,
             skills: AllSkillsResolve,
             comments: AllCommentsResolve,
-            selectedTeam: TeamsSelectionResolve
+            selectedTeam: TeamsSelectionResolve,
+            trainings: AllTrainingsResolve
         },
         data: {
             authorities: [],

--- a/src/main/webapp/i18n/de/global.json
+++ b/src/main/webapp/i18n/de/global.json
@@ -20,6 +20,7 @@
                 "comment": "Comment",
                 "activity": "Activity",
                 "image": "Image",
+                "training": "Training",
                 "jhipster-needle-menu-add-entry": "JHipster will add additional entities here (do not translate!)"
             },
             "account": {

--- a/src/main/webapp/i18n/de/teams.json
+++ b/src/main/webapp/i18n/de/teams.json
@@ -41,6 +41,8 @@
                     "achievedBy": "Erfüllt von",
                     "achievedByNone" : "Dieser Skill wurde noch von keinem Team erfüllt!",
                     "neededFor": "Benötigt für",
+                    "trainings": "Hilfreiche Weiterbildungsangebote",
+                    "noTrainings": "Keine hilfreichen Weiterbildungsangebote verfügbar",
                     "3of5": "3 von 5 Sternen",
                     "contact": "Ansprechpartner"
                 },

--- a/src/main/webapp/i18n/de/training.json
+++ b/src/main/webapp/i18n/de/training.json
@@ -21,6 +21,7 @@
             "contactPerson": "Contact Person",
             "link": "Link",
             "validUntil": "Valid Until",
+            "validUntilPlaceholder": "z.B. 2029-01-01T00:00:00+01:00",
             "isOfficial": "Is Official",
             "skill": "Skill"
         }

--- a/src/main/webapp/i18n/de/training.json
+++ b/src/main/webapp/i18n/de/training.json
@@ -1,0 +1,28 @@
+
+{
+    "teamdojoApp": {
+        "training" : {
+            "home": {
+                "title": "Trainings",
+                "createLabel": "Training erstellen",
+                "createOrEditLabel": "Training erstellen oder bearbeiten"
+            },
+            "created": "Training erstellt mit ID {{ param }}",
+            "updated": "Training aktualisiert mit ID {{ param }}",
+            "deleted": "Training gelöscht mit ID {{ param }}",
+            "delete": {
+                "question": "Soll Training {{ id }} wirklich dauerhaft gelöscht werden?"
+            },
+            "detail": {
+                "title": "Training"
+            },
+            "title": "Title",
+            "description": "Description",
+            "contactPerson": "Contact Person",
+            "link": "Link",
+            "validUntil": "Valid Until",
+            "isOfficial": "Is Official",
+            "skill": "Skill"
+        }
+    }
+}

--- a/src/main/webapp/i18n/de_person/global.json
+++ b/src/main/webapp/i18n/de_person/global.json
@@ -20,6 +20,7 @@
                 "comment": "Comment",
                 "activity": "Activity",
                 "image": "Image",
+                "training": "Training",
                 "jhipster-needle-menu-add-entry": "JHipster will add additional entities here (do not translate!)"
             },
             "account": {

--- a/src/main/webapp/i18n/de_person/teams.json
+++ b/src/main/webapp/i18n/de_person/teams.json
@@ -41,6 +41,8 @@
                     "achievedBy": "Erfüllt von",
                     "achievedByNone" : "Dieser Skill wurde noch von keiner Person erfüllt!",
                     "neededFor": "Benötigt für",
+                    "trainings": "Hilfreiche Weiterbildungsangebote",
+                    "noTrainings": "Keine hilfreichen Weiterbildungsangebote verfügbar",
                     "3of5": "3 von 5 Sternen",
                     "contact": "Ansprechpartner"
                 },

--- a/src/main/webapp/i18n/de_person/training.json
+++ b/src/main/webapp/i18n/de_person/training.json
@@ -21,6 +21,7 @@
             "contactPerson": "Contact Person",
             "link": "Link",
             "validUntil": "Valid Until",
+            "validUntilPlaceholder": "z.B. 2029-01-01T00:00:00+01:00",
             "isOfficial": "Is Official",
             "skill": "Skill"
         }

--- a/src/main/webapp/i18n/de_person/training.json
+++ b/src/main/webapp/i18n/de_person/training.json
@@ -1,0 +1,28 @@
+
+{
+    "teamdojoApp": {
+        "training" : {
+            "home": {
+                "title": "Trainings",
+                "createLabel": "Training erstellen",
+                "createOrEditLabel": "Training erstellen oder bearbeiten"
+            },
+            "created": "Training erstellt mit ID {{ param }}",
+            "updated": "Training aktualisiert mit ID {{ param }}",
+            "deleted": "Training gelöscht mit ID {{ param }}",
+            "delete": {
+                "question": "Soll Training {{ id }} wirklich dauerhaft gelöscht werden?"
+            },
+            "detail": {
+                "title": "Training"
+            },
+            "title": "Title",
+            "description": "Description",
+            "contactPerson": "Contact Person",
+            "link": "Link",
+            "validUntil": "Valid Until",
+            "isOfficial": "Is Official",
+            "skill": "Skill"
+        }
+    }
+}

--- a/src/main/webapp/i18n/en/global.json
+++ b/src/main/webapp/i18n/en/global.json
@@ -20,6 +20,7 @@
                 "comment": "Comment",
                 "activity": "Activity",
                 "image": "Image",
+                "training": "Training",
                 "jhipster-needle-menu-add-entry": "JHipster will add additional entities here (do not translate!)"
             },
             "account": {

--- a/src/main/webapp/i18n/en/teams.json
+++ b/src/main/webapp/i18n/en/teams.json
@@ -41,6 +41,8 @@
                     "achievedBy": "Achieved by",
                     "achievedByNone" : "No teams have achieved this skill yet!",
                     "neededFor": "Needed for",
+                    "trainings": "Helpful trainings",
+                    "noTrainings": "No helpful trainings available",
                     "3of5": "3 out of 5 stars",
                     "contact": "Contact"
                 },

--- a/src/main/webapp/i18n/en/training.json
+++ b/src/main/webapp/i18n/en/training.json
@@ -1,0 +1,28 @@
+
+{
+    "teamdojoApp": {
+        "training" : {
+            "home": {
+                "title": "Trainings",
+                "createLabel": "Create a new Training",
+                "createOrEditLabel": "Create or edit a Training"
+            },
+            "created": "A new Training is created with identifier {{ param }}",
+            "updated": "A Training is updated with identifier {{ param }}",
+            "deleted": "A Training is deleted with identifier {{ param }}",
+            "delete": {
+                "question": "Are you sure you want to delete Training {{ id }}?"
+            },
+            "detail": {
+                "title": "Training"
+            },
+            "title": "Title",
+            "description": "Description",
+            "contactPerson": "Contact Person",
+            "link": "Link",
+            "validUntil": "Valid Until",
+            "isOfficial": "Is Official",
+            "skill": "Skill"
+        }
+    }
+}

--- a/src/main/webapp/i18n/en/training.json
+++ b/src/main/webapp/i18n/en/training.json
@@ -21,6 +21,7 @@
             "contactPerson": "Contact Person",
             "link": "Link",
             "validUntil": "Valid Until",
+            "validUntilPlaceholder": "e.g. 2029-01-01T00:00:00+01:00",
             "isOfficial": "Is Official",
             "skill": "Skill"
         }

--- a/src/main/webapp/i18n/en_person/global.json
+++ b/src/main/webapp/i18n/en_person/global.json
@@ -20,6 +20,7 @@
                 "comment": "Comment",
                 "activity": "Activity",
                 "image": "Image",
+                "training": "Training",
                 "jhipster-needle-menu-add-entry": "JHipster will add additional entities here (do not translate!)"
             },
             "account": {

--- a/src/main/webapp/i18n/en_person/teams.json
+++ b/src/main/webapp/i18n/en_person/teams.json
@@ -41,6 +41,8 @@
                     "achievedBy": "Achieved by",
                     "achievedByNone" : "No Persons have achieved this skill yet!",
                     "neededFor": "Needed for",
+                    "trainings": "Helpful trainings",
+                    "noTrainings": "No helpful trainings available",
                     "3of5": "3 out of 5 stars",
                     "contact": "Contact"
                 },

--- a/src/main/webapp/i18n/en_person/training.json
+++ b/src/main/webapp/i18n/en_person/training.json
@@ -1,0 +1,28 @@
+
+{
+    "teamdojoApp": {
+        "training" : {
+            "home": {
+                "title": "Trainings",
+                "createLabel": "Create a new Training",
+                "createOrEditLabel": "Create or edit a Training"
+            },
+            "created": "A new Training is created with identifier {{ param }}",
+            "updated": "A Training is updated with identifier {{ param }}",
+            "deleted": "A Training is deleted with identifier {{ param }}",
+            "delete": {
+                "question": "Are you sure you want to delete Training {{ id }}?"
+            },
+            "detail": {
+                "title": "Training"
+            },
+            "title": "Title",
+            "description": "Description",
+            "contactPerson": "Contact Person",
+            "link": "Link",
+            "validUntil": "Valid Until",
+            "isOfficial": "Is Official",
+            "skill": "Skill"
+        }
+    }
+}

--- a/src/main/webapp/i18n/en_person/training.json
+++ b/src/main/webapp/i18n/en_person/training.json
@@ -21,6 +21,7 @@
             "contactPerson": "Contact Person",
             "link": "Link",
             "validUntil": "Valid Until",
+            "validUntilPlaceholder": "e.g. 2029-01-01T00:00:00+01:00",
             "isOfficial": "Is Official",
             "skill": "Skill"
         }

--- a/src/test/java/de/otto/teamdojo/web/rest/SkillResourceIntTest.java
+++ b/src/test/java/de/otto/teamdojo/web/rest/SkillResourceIntTest.java
@@ -1,20 +1,24 @@
 package de.otto.teamdojo.web.rest;
 
 import de.otto.teamdojo.TeamdojoApp;
-import de.otto.teamdojo.domain.BadgeSkill;
-import de.otto.teamdojo.domain.LevelSkill;
+
 import de.otto.teamdojo.domain.Skill;
 import de.otto.teamdojo.domain.TeamSkill;
+import de.otto.teamdojo.domain.BadgeSkill;
+import de.otto.teamdojo.domain.LevelSkill;
+import de.otto.teamdojo.domain.Training;
 import de.otto.teamdojo.repository.SkillRepository;
-import de.otto.teamdojo.service.SkillQueryService;
 import de.otto.teamdojo.service.SkillService;
 import de.otto.teamdojo.service.dto.SkillDTO;
-import de.otto.teamdojo.service.dto.SkillRateDTO;
 import de.otto.teamdojo.service.mapper.SkillMapper;
 import de.otto.teamdojo.web.rest.errors.ExceptionTranslator;
+import de.otto.teamdojo.service.dto.SkillCriteria;
+import de.otto.teamdojo.service.SkillQueryService;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -28,6 +32,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityManager;
 import java.util.List;
+import java.util.ArrayList;
 
 import static de.otto.teamdojo.web.rest.TestUtil.createFormattingConversionService;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -240,10 +245,9 @@ public class SkillResourceIntTest {
             .andExpect(jsonPath("$.[*].validation").value(hasItem(DEFAULT_VALIDATION.toString())))
             .andExpect(jsonPath("$.[*].expiryPeriod").value(hasItem(DEFAULT_EXPIRY_PERIOD.toString())))
             .andExpect(jsonPath("$.[*].contact").value(hasItem(DEFAULT_CONTACT.toString())))
+            .andExpect(jsonPath("$.[*].score").value(hasItem(DEFAULT_SCORE)))
             .andExpect(jsonPath("$.[*].rateScore").value(hasItem(DEFAULT_RATE_SCORE.doubleValue())))
-            .andExpect(jsonPath("$.[*].rateCount").value(hasItem(DEFAULT_RATE_COUNT)))
-            .andExpect(jsonPath("$.[*].contact").value(hasItem(DEFAULT_CONTACT.toString())))
-            .andExpect(jsonPath("$.[*].score").value(hasItem(DEFAULT_SCORE)));
+            .andExpect(jsonPath("$.[*].rateCount").value(hasItem(DEFAULT_RATE_COUNT)));
     }
 
 
@@ -265,7 +269,6 @@ public class SkillResourceIntTest {
             .andExpect(jsonPath("$.expiryPeriod").value(DEFAULT_EXPIRY_PERIOD.toString()))
             .andExpect(jsonPath("$.contact").value(DEFAULT_CONTACT.toString()))
             .andExpect(jsonPath("$.score").value(DEFAULT_SCORE))
-            .andExpect(jsonPath("$.contact").value(DEFAULT_CONTACT.toString()))
             .andExpect(jsonPath("$.rateScore").value(DEFAULT_RATE_SCORE.doubleValue()))
             .andExpect(jsonPath("$.rateCount").value(DEFAULT_RATE_COUNT));
     }
@@ -570,7 +573,9 @@ public class SkillResourceIntTest {
     }
 
 
-    @Test @Transactional public void getAllSkillsByRateScoreIsEqualToSomething() throws Exception {
+    @Test
+    @Transactional
+    public void getAllSkillsByRateScoreIsEqualToSomething() throws Exception {
         // Initialize the database
         skillRepository.saveAndFlush(skill);
 
@@ -581,7 +586,9 @@ public class SkillResourceIntTest {
         defaultSkillShouldNotBeFound("rateScore.equals=" + UPDATED_RATE_SCORE);
     }
 
-    @Test @Transactional public void getAllSkillsByRateScoreIsInShouldWork() throws Exception {
+    @Test
+    @Transactional
+    public void getAllSkillsByRateScoreIsInShouldWork() throws Exception {
         // Initialize the database
         skillRepository.saveAndFlush(skill);
 
@@ -592,7 +599,9 @@ public class SkillResourceIntTest {
         defaultSkillShouldNotBeFound("rateScore.in=" + UPDATED_RATE_SCORE);
     }
 
-    @Test @Transactional public void getAllSkillsByRateScoreIsNullOrNotNull() throws Exception {
+    @Test
+    @Transactional
+    public void getAllSkillsByRateScoreIsNullOrNotNull() throws Exception {
         // Initialize the database
         skillRepository.saveAndFlush(skill);
 
@@ -603,7 +612,9 @@ public class SkillResourceIntTest {
         defaultSkillShouldNotBeFound("rateScore.specified=false");
     }
 
-    @Test @Transactional public void getAllSkillsByRateCountIsEqualToSomething() throws Exception {
+    @Test
+    @Transactional
+    public void getAllSkillsByRateCountIsEqualToSomething() throws Exception {
         // Initialize the database
         skillRepository.saveAndFlush(skill);
 
@@ -614,7 +625,9 @@ public class SkillResourceIntTest {
         defaultSkillShouldNotBeFound("rateCount.equals=" + UPDATED_RATE_COUNT);
     }
 
-    @Test @Transactional public void getAllSkillsByRateCountIsInShouldWork() throws Exception {
+    @Test
+    @Transactional
+    public void getAllSkillsByRateCountIsInShouldWork() throws Exception {
         // Initialize the database
         skillRepository.saveAndFlush(skill);
 
@@ -625,7 +638,9 @@ public class SkillResourceIntTest {
         defaultSkillShouldNotBeFound("rateCount.in=" + UPDATED_RATE_COUNT);
     }
 
-    @Test @Transactional public void getAllSkillsByRateCountIsNullOrNotNull() throws Exception {
+    @Test
+    @Transactional
+    public void getAllSkillsByRateCountIsNullOrNotNull() throws Exception {
         // Initialize the database
         skillRepository.saveAndFlush(skill);
 
@@ -636,7 +651,9 @@ public class SkillResourceIntTest {
         defaultSkillShouldNotBeFound("rateCount.specified=false");
     }
 
-    @Test @Transactional public void getAllSkillsByRateCountIsGreaterThanOrEqualToSomething() throws Exception {
+    @Test
+    @Transactional
+    public void getAllSkillsByRateCountIsGreaterThanOrEqualToSomething() throws Exception {
         // Initialize the database
         skillRepository.saveAndFlush(skill);
 
@@ -647,7 +664,9 @@ public class SkillResourceIntTest {
         defaultSkillShouldNotBeFound("rateCount.greaterOrEqualThan=" + UPDATED_RATE_COUNT);
     }
 
-    @Test @Transactional public void getAllSkillsByRateCountIsLessThanSomething() throws Exception {
+    @Test
+    @Transactional
+    public void getAllSkillsByRateCountIsLessThanSomething() throws Exception {
         // Initialize the database
         skillRepository.saveAndFlush(skill);
 
@@ -657,6 +676,7 @@ public class SkillResourceIntTest {
         // Get all the skillList where rateCount less than or equals to UPDATED_RATE_COUNT
         defaultSkillShouldBeFound("rateCount.lessThan=" + UPDATED_RATE_COUNT);
     }
+
 
     @Test
     @Transactional
@@ -714,6 +734,25 @@ public class SkillResourceIntTest {
         defaultSkillShouldNotBeFound("levelsId.equals=" + (levelsId + 1));
     }
 
+
+    @Test
+    @Transactional
+    public void getAllSkillsByTrainingsIsEqualToSomething() throws Exception {
+        // Initialize the database
+        Training trainings = TrainingResourceIntTest.createEntity(em);
+        em.persist(trainings);
+        em.flush();
+        skill.addTrainings(trainings);
+        skillRepository.saveAndFlush(skill);
+        Long trainingsId = trainings.getId();
+
+        // Get all the skillList where trainings equals to trainingsId
+        defaultSkillShouldBeFound("trainingsId.equals=" + trainingsId);
+
+        // Get all the skillList where trainings equals to trainingsId + 1
+        defaultSkillShouldNotBeFound("trainingsId.equals=" + (trainingsId + 1));
+    }
+
     /**
      * Executes the search, and checks that the default entity is returned
      */
@@ -729,7 +768,6 @@ public class SkillResourceIntTest {
             .andExpect(jsonPath("$.[*].expiryPeriod").value(hasItem(DEFAULT_EXPIRY_PERIOD.toString())))
             .andExpect(jsonPath("$.[*].contact").value(hasItem(DEFAULT_CONTACT.toString())))
             .andExpect(jsonPath("$.[*].score").value(hasItem(DEFAULT_SCORE)))
-            .andExpect(jsonPath("$.[*].contact").value(hasItem(DEFAULT_CONTACT.toString())))
             .andExpect(jsonPath("$.[*].rateScore").value(hasItem(DEFAULT_RATE_SCORE.doubleValue())))
             .andExpect(jsonPath("$.[*].rateCount").value(hasItem(DEFAULT_RATE_COUNT)));
     }
@@ -774,7 +812,7 @@ public class SkillResourceIntTest {
             .expiryPeriod(UPDATED_EXPIRY_PERIOD)
             .contact(UPDATED_CONTACT)
             .score(UPDATED_SCORE)
-            .expiryPeriod(UPDATED_EXPIRY_PERIOD).contact(UPDATED_CONTACT).rateScore(UPDATED_RATE_SCORE)
+            .rateScore(UPDATED_RATE_SCORE)
             .rateCount(UPDATED_RATE_COUNT);
         SkillDTO skillDTO = skillMapper.toDto(updatedSkill);
 

--- a/src/test/java/de/otto/teamdojo/web/rest/TrainingResourceIntTest.java
+++ b/src/test/java/de/otto/teamdojo/web/rest/TrainingResourceIntTest.java
@@ -60,8 +60,8 @@ public class TrainingResourceIntTest {
     private static final String DEFAULT_CONTACT_PERSON = "AAAAAAAAAA";
     private static final String UPDATED_CONTACT_PERSON = "BBBBBBBBBB";
 
-    private static final String DEFAULT_LINK = "AAAAAAAAAA";
-    private static final String UPDATED_LINK = "BBBBBBBBBB";
+    private static final String DEFAULT_LINK = "https://9V.Nd.wHd";
+    private static final String UPDATED_LINK = "E.Mg.VDR";
 
     private static final Instant DEFAULT_VALID_UNTIL = Instant.ofEpochMilli(0L);
     private static final Instant UPDATED_VALID_UNTIL = Instant.now().truncatedTo(ChronoUnit.MILLIS);

--- a/src/test/java/de/otto/teamdojo/web/rest/TrainingResourceIntTest.java
+++ b/src/test/java/de/otto/teamdojo/web/rest/TrainingResourceIntTest.java
@@ -1,0 +1,690 @@
+package de.otto.teamdojo.web.rest;
+
+import de.otto.teamdojo.TeamdojoApp;
+
+import de.otto.teamdojo.domain.Training;
+import de.otto.teamdojo.domain.Skill;
+import de.otto.teamdojo.repository.TrainingRepository;
+import de.otto.teamdojo.service.TrainingService;
+import de.otto.teamdojo.service.dto.TrainingDTO;
+import de.otto.teamdojo.service.mapper.TrainingMapper;
+import de.otto.teamdojo.web.rest.errors.ExceptionTranslator;
+import de.otto.teamdojo.service.dto.TrainingCriteria;
+import de.otto.teamdojo.service.TrainingQueryService;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.ArrayList;
+
+import static de.otto.teamdojo.web.rest.TestUtil.createFormattingConversionService;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * Test class for the TrainingResource REST controller.
+ *
+ * @see TrainingResource
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = TeamdojoApp.class)
+public class TrainingResourceIntTest {
+
+    private static final String DEFAULT_TITLE = "AAAAAAAAAA";
+    private static final String UPDATED_TITLE = "BBBBBBBBBB";
+
+    private static final String DEFAULT_DESCRIPTION = "AAAAAAAAAA";
+    private static final String UPDATED_DESCRIPTION = "BBBBBBBBBB";
+
+    private static final String DEFAULT_CONTACT_PERSON = "AAAAAAAAAA";
+    private static final String UPDATED_CONTACT_PERSON = "BBBBBBBBBB";
+
+    private static final String DEFAULT_LINK = "AAAAAAAAAA";
+    private static final String UPDATED_LINK = "BBBBBBBBBB";
+
+    private static final Instant DEFAULT_VALID_UNTIL = Instant.ofEpochMilli(0L);
+    private static final Instant UPDATED_VALID_UNTIL = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+
+    private static final Boolean DEFAULT_IS_OFFICIAL = false;
+    private static final Boolean UPDATED_IS_OFFICIAL = true;
+
+    @Autowired
+    private TrainingRepository trainingRepository;
+
+    @Mock
+    private TrainingRepository trainingRepositoryMock;
+
+    @Autowired
+    private TrainingMapper trainingMapper;
+    
+    @Mock
+    private TrainingService trainingServiceMock;
+
+    @Autowired
+    private TrainingService trainingService;
+
+    @Autowired
+    private TrainingQueryService trainingQueryService;
+
+    @Autowired
+    private MappingJackson2HttpMessageConverter jacksonMessageConverter;
+
+    @Autowired
+    private PageableHandlerMethodArgumentResolver pageableArgumentResolver;
+
+    @Autowired
+    private ExceptionTranslator exceptionTranslator;
+
+    @Autowired
+    private EntityManager em;
+
+    private MockMvc restTrainingMockMvc;
+
+    private Training training;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+        final TrainingResource trainingResource = new TrainingResource(trainingService, trainingQueryService);
+        this.restTrainingMockMvc = MockMvcBuilders.standaloneSetup(trainingResource)
+            .setCustomArgumentResolvers(pageableArgumentResolver)
+            .setControllerAdvice(exceptionTranslator)
+            .setConversionService(createFormattingConversionService())
+            .setMessageConverters(jacksonMessageConverter).build();
+    }
+
+    /**
+     * Create an entity for this test.
+     *
+     * This is a static method, as tests for other entities might also need it,
+     * if they test an entity which requires the current entity.
+     */
+    public static Training createEntity(EntityManager em) {
+        Training training = new Training()
+            .title(DEFAULT_TITLE)
+            .description(DEFAULT_DESCRIPTION)
+            .contactPerson(DEFAULT_CONTACT_PERSON)
+            .link(DEFAULT_LINK)
+            .validUntil(DEFAULT_VALID_UNTIL)
+            .isOfficial(DEFAULT_IS_OFFICIAL);
+        return training;
+    }
+
+    @Before
+    public void initTest() {
+        training = createEntity(em);
+    }
+
+    @Test
+    @Transactional
+    public void createTraining() throws Exception {
+        int databaseSizeBeforeCreate = trainingRepository.findAll().size();
+
+        // Create the Training
+        TrainingDTO trainingDTO = trainingMapper.toDto(training);
+        restTrainingMockMvc.perform(post("/api/trainings")
+            .contentType(TestUtil.APPLICATION_JSON_UTF8)
+            .content(TestUtil.convertObjectToJsonBytes(trainingDTO)))
+            .andExpect(status().isCreated());
+
+        // Validate the Training in the database
+        List<Training> trainingList = trainingRepository.findAll();
+        assertThat(trainingList).hasSize(databaseSizeBeforeCreate + 1);
+        Training testTraining = trainingList.get(trainingList.size() - 1);
+        assertThat(testTraining.getTitle()).isEqualTo(DEFAULT_TITLE);
+        assertThat(testTraining.getDescription()).isEqualTo(DEFAULT_DESCRIPTION);
+        assertThat(testTraining.getContactPerson()).isEqualTo(DEFAULT_CONTACT_PERSON);
+        assertThat(testTraining.getLink()).isEqualTo(DEFAULT_LINK);
+        assertThat(testTraining.getValidUntil()).isEqualTo(DEFAULT_VALID_UNTIL);
+        assertThat(testTraining.isIsOfficial()).isEqualTo(DEFAULT_IS_OFFICIAL);
+    }
+
+    @Test
+    @Transactional
+    public void createTrainingWithExistingId() throws Exception {
+        int databaseSizeBeforeCreate = trainingRepository.findAll().size();
+
+        // Create the Training with an existing ID
+        training.setId(1L);
+        TrainingDTO trainingDTO = trainingMapper.toDto(training);
+
+        // An entity with an existing ID cannot be created, so this API call must fail
+        restTrainingMockMvc.perform(post("/api/trainings")
+            .contentType(TestUtil.APPLICATION_JSON_UTF8)
+            .content(TestUtil.convertObjectToJsonBytes(trainingDTO)))
+            .andExpect(status().isBadRequest());
+
+        // Validate the Training in the database
+        List<Training> trainingList = trainingRepository.findAll();
+        assertThat(trainingList).hasSize(databaseSizeBeforeCreate);
+    }
+
+    @Test
+    @Transactional
+    public void checkTitleIsRequired() throws Exception {
+        int databaseSizeBeforeTest = trainingRepository.findAll().size();
+        // set the field null
+        training.setTitle(null);
+
+        // Create the Training, which fails.
+        TrainingDTO trainingDTO = trainingMapper.toDto(training);
+
+        restTrainingMockMvc.perform(post("/api/trainings")
+            .contentType(TestUtil.APPLICATION_JSON_UTF8)
+            .content(TestUtil.convertObjectToJsonBytes(trainingDTO)))
+            .andExpect(status().isBadRequest());
+
+        List<Training> trainingList = trainingRepository.findAll();
+        assertThat(trainingList).hasSize(databaseSizeBeforeTest);
+    }
+
+    @Test
+    @Transactional
+    public void checkIsOfficialIsRequired() throws Exception {
+        int databaseSizeBeforeTest = trainingRepository.findAll().size();
+        // set the field null
+        training.setIsOfficial(null);
+
+        // Create the Training, which fails.
+        TrainingDTO trainingDTO = trainingMapper.toDto(training);
+
+        restTrainingMockMvc.perform(post("/api/trainings")
+            .contentType(TestUtil.APPLICATION_JSON_UTF8)
+            .content(TestUtil.convertObjectToJsonBytes(trainingDTO)))
+            .andExpect(status().isBadRequest());
+
+        List<Training> trainingList = trainingRepository.findAll();
+        assertThat(trainingList).hasSize(databaseSizeBeforeTest);
+    }
+
+    @Test
+    @Transactional
+    public void getAllTrainings() throws Exception {
+        // Initialize the database
+        trainingRepository.saveAndFlush(training);
+
+        // Get all the trainingList
+        restTrainingMockMvc.perform(get("/api/trainings?sort=id,desc"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+            .andExpect(jsonPath("$.[*].id").value(hasItem(training.getId().intValue())))
+            .andExpect(jsonPath("$.[*].title").value(hasItem(DEFAULT_TITLE.toString())))
+            .andExpect(jsonPath("$.[*].description").value(hasItem(DEFAULT_DESCRIPTION.toString())))
+            .andExpect(jsonPath("$.[*].contactPerson").value(hasItem(DEFAULT_CONTACT_PERSON.toString())))
+            .andExpect(jsonPath("$.[*].link").value(hasItem(DEFAULT_LINK.toString())))
+            .andExpect(jsonPath("$.[*].validUntil").value(hasItem(DEFAULT_VALID_UNTIL.toString())))
+            .andExpect(jsonPath("$.[*].isOfficial").value(hasItem(DEFAULT_IS_OFFICIAL.booleanValue())));
+    }
+    
+    public void getAllTrainingsWithEagerRelationshipsIsEnabled() throws Exception {
+        TrainingResource trainingResource = new TrainingResource(trainingServiceMock, trainingQueryService);
+        when(trainingServiceMock.findAllWithEagerRelationships(any())).thenReturn(new PageImpl(new ArrayList<>()));
+
+        MockMvc restTrainingMockMvc = MockMvcBuilders.standaloneSetup(trainingResource)
+            .setCustomArgumentResolvers(pageableArgumentResolver)
+            .setControllerAdvice(exceptionTranslator)
+            .setConversionService(createFormattingConversionService())
+            .setMessageConverters(jacksonMessageConverter).build();
+
+        restTrainingMockMvc.perform(get("/api/trainings?eagerload=true"))
+        .andExpect(status().isOk());
+
+        verify(trainingServiceMock, times(1)).findAllWithEagerRelationships(any());
+    }
+
+    public void getAllTrainingsWithEagerRelationshipsIsNotEnabled() throws Exception {
+        TrainingResource trainingResource = new TrainingResource(trainingServiceMock, trainingQueryService);
+            when(trainingServiceMock.findAllWithEagerRelationships(any())).thenReturn(new PageImpl(new ArrayList<>()));
+            MockMvc restTrainingMockMvc = MockMvcBuilders.standaloneSetup(trainingResource)
+            .setCustomArgumentResolvers(pageableArgumentResolver)
+            .setControllerAdvice(exceptionTranslator)
+            .setConversionService(createFormattingConversionService())
+            .setMessageConverters(jacksonMessageConverter).build();
+
+        restTrainingMockMvc.perform(get("/api/trainings?eagerload=true"))
+        .andExpect(status().isOk());
+
+            verify(trainingServiceMock, times(1)).findAllWithEagerRelationships(any());
+    }
+
+    @Test
+    @Transactional
+    public void getTraining() throws Exception {
+        // Initialize the database
+        trainingRepository.saveAndFlush(training);
+
+        // Get the training
+        restTrainingMockMvc.perform(get("/api/trainings/{id}", training.getId()))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+            .andExpect(jsonPath("$.id").value(training.getId().intValue()))
+            .andExpect(jsonPath("$.title").value(DEFAULT_TITLE.toString()))
+            .andExpect(jsonPath("$.description").value(DEFAULT_DESCRIPTION.toString()))
+            .andExpect(jsonPath("$.contactPerson").value(DEFAULT_CONTACT_PERSON.toString()))
+            .andExpect(jsonPath("$.link").value(DEFAULT_LINK.toString()))
+            .andExpect(jsonPath("$.validUntil").value(DEFAULT_VALID_UNTIL.toString()))
+            .andExpect(jsonPath("$.isOfficial").value(DEFAULT_IS_OFFICIAL.booleanValue()));
+    }
+
+    @Test
+    @Transactional
+    public void getAllTrainingsByTitleIsEqualToSomething() throws Exception {
+        // Initialize the database
+        trainingRepository.saveAndFlush(training);
+
+        // Get all the trainingList where title equals to DEFAULT_TITLE
+        defaultTrainingShouldBeFound("title.equals=" + DEFAULT_TITLE);
+
+        // Get all the trainingList where title equals to UPDATED_TITLE
+        defaultTrainingShouldNotBeFound("title.equals=" + UPDATED_TITLE);
+    }
+
+    @Test
+    @Transactional
+    public void getAllTrainingsByTitleIsInShouldWork() throws Exception {
+        // Initialize the database
+        trainingRepository.saveAndFlush(training);
+
+        // Get all the trainingList where title in DEFAULT_TITLE or UPDATED_TITLE
+        defaultTrainingShouldBeFound("title.in=" + DEFAULT_TITLE + "," + UPDATED_TITLE);
+
+        // Get all the trainingList where title equals to UPDATED_TITLE
+        defaultTrainingShouldNotBeFound("title.in=" + UPDATED_TITLE);
+    }
+
+    @Test
+    @Transactional
+    public void getAllTrainingsByTitleIsNullOrNotNull() throws Exception {
+        // Initialize the database
+        trainingRepository.saveAndFlush(training);
+
+        // Get all the trainingList where title is not null
+        defaultTrainingShouldBeFound("title.specified=true");
+
+        // Get all the trainingList where title is null
+        defaultTrainingShouldNotBeFound("title.specified=false");
+    }
+
+    @Test
+    @Transactional
+    public void getAllTrainingsByDescriptionIsEqualToSomething() throws Exception {
+        // Initialize the database
+        trainingRepository.saveAndFlush(training);
+
+        // Get all the trainingList where description equals to DEFAULT_DESCRIPTION
+        defaultTrainingShouldBeFound("description.equals=" + DEFAULT_DESCRIPTION);
+
+        // Get all the trainingList where description equals to UPDATED_DESCRIPTION
+        defaultTrainingShouldNotBeFound("description.equals=" + UPDATED_DESCRIPTION);
+    }
+
+    @Test
+    @Transactional
+    public void getAllTrainingsByDescriptionIsInShouldWork() throws Exception {
+        // Initialize the database
+        trainingRepository.saveAndFlush(training);
+
+        // Get all the trainingList where description in DEFAULT_DESCRIPTION or UPDATED_DESCRIPTION
+        defaultTrainingShouldBeFound("description.in=" + DEFAULT_DESCRIPTION + "," + UPDATED_DESCRIPTION);
+
+        // Get all the trainingList where description equals to UPDATED_DESCRIPTION
+        defaultTrainingShouldNotBeFound("description.in=" + UPDATED_DESCRIPTION);
+    }
+
+    @Test
+    @Transactional
+    public void getAllTrainingsByDescriptionIsNullOrNotNull() throws Exception {
+        // Initialize the database
+        trainingRepository.saveAndFlush(training);
+
+        // Get all the trainingList where description is not null
+        defaultTrainingShouldBeFound("description.specified=true");
+
+        // Get all the trainingList where description is null
+        defaultTrainingShouldNotBeFound("description.specified=false");
+    }
+
+    @Test
+    @Transactional
+    public void getAllTrainingsByContactPersonIsEqualToSomething() throws Exception {
+        // Initialize the database
+        trainingRepository.saveAndFlush(training);
+
+        // Get all the trainingList where contactPerson equals to DEFAULT_CONTACT_PERSON
+        defaultTrainingShouldBeFound("contactPerson.equals=" + DEFAULT_CONTACT_PERSON);
+
+        // Get all the trainingList where contactPerson equals to UPDATED_CONTACT_PERSON
+        defaultTrainingShouldNotBeFound("contactPerson.equals=" + UPDATED_CONTACT_PERSON);
+    }
+
+    @Test
+    @Transactional
+    public void getAllTrainingsByContactPersonIsInShouldWork() throws Exception {
+        // Initialize the database
+        trainingRepository.saveAndFlush(training);
+
+        // Get all the trainingList where contactPerson in DEFAULT_CONTACT_PERSON or UPDATED_CONTACT_PERSON
+        defaultTrainingShouldBeFound("contactPerson.in=" + DEFAULT_CONTACT_PERSON + "," + UPDATED_CONTACT_PERSON);
+
+        // Get all the trainingList where contactPerson equals to UPDATED_CONTACT_PERSON
+        defaultTrainingShouldNotBeFound("contactPerson.in=" + UPDATED_CONTACT_PERSON);
+    }
+
+    @Test
+    @Transactional
+    public void getAllTrainingsByContactPersonIsNullOrNotNull() throws Exception {
+        // Initialize the database
+        trainingRepository.saveAndFlush(training);
+
+        // Get all the trainingList where contactPerson is not null
+        defaultTrainingShouldBeFound("contactPerson.specified=true");
+
+        // Get all the trainingList where contactPerson is null
+        defaultTrainingShouldNotBeFound("contactPerson.specified=false");
+    }
+
+    @Test
+    @Transactional
+    public void getAllTrainingsByLinkIsEqualToSomething() throws Exception {
+        // Initialize the database
+        trainingRepository.saveAndFlush(training);
+
+        // Get all the trainingList where link equals to DEFAULT_LINK
+        defaultTrainingShouldBeFound("link.equals=" + DEFAULT_LINK);
+
+        // Get all the trainingList where link equals to UPDATED_LINK
+        defaultTrainingShouldNotBeFound("link.equals=" + UPDATED_LINK);
+    }
+
+    @Test
+    @Transactional
+    public void getAllTrainingsByLinkIsInShouldWork() throws Exception {
+        // Initialize the database
+        trainingRepository.saveAndFlush(training);
+
+        // Get all the trainingList where link in DEFAULT_LINK or UPDATED_LINK
+        defaultTrainingShouldBeFound("link.in=" + DEFAULT_LINK + "," + UPDATED_LINK);
+
+        // Get all the trainingList where link equals to UPDATED_LINK
+        defaultTrainingShouldNotBeFound("link.in=" + UPDATED_LINK);
+    }
+
+    @Test
+    @Transactional
+    public void getAllTrainingsByLinkIsNullOrNotNull() throws Exception {
+        // Initialize the database
+        trainingRepository.saveAndFlush(training);
+
+        // Get all the trainingList where link is not null
+        defaultTrainingShouldBeFound("link.specified=true");
+
+        // Get all the trainingList where link is null
+        defaultTrainingShouldNotBeFound("link.specified=false");
+    }
+
+    @Test
+    @Transactional
+    public void getAllTrainingsByValidUntilIsEqualToSomething() throws Exception {
+        // Initialize the database
+        trainingRepository.saveAndFlush(training);
+
+        // Get all the trainingList where validUntil equals to DEFAULT_VALID_UNTIL
+        defaultTrainingShouldBeFound("validUntil.equals=" + DEFAULT_VALID_UNTIL);
+
+        // Get all the trainingList where validUntil equals to UPDATED_VALID_UNTIL
+        defaultTrainingShouldNotBeFound("validUntil.equals=" + UPDATED_VALID_UNTIL);
+    }
+
+    @Test
+    @Transactional
+    public void getAllTrainingsByValidUntilIsInShouldWork() throws Exception {
+        // Initialize the database
+        trainingRepository.saveAndFlush(training);
+
+        // Get all the trainingList where validUntil in DEFAULT_VALID_UNTIL or UPDATED_VALID_UNTIL
+        defaultTrainingShouldBeFound("validUntil.in=" + DEFAULT_VALID_UNTIL + "," + UPDATED_VALID_UNTIL);
+
+        // Get all the trainingList where validUntil equals to UPDATED_VALID_UNTIL
+        defaultTrainingShouldNotBeFound("validUntil.in=" + UPDATED_VALID_UNTIL);
+    }
+
+    @Test
+    @Transactional
+    public void getAllTrainingsByValidUntilIsNullOrNotNull() throws Exception {
+        // Initialize the database
+        trainingRepository.saveAndFlush(training);
+
+        // Get all the trainingList where validUntil is not null
+        defaultTrainingShouldBeFound("validUntil.specified=true");
+
+        // Get all the trainingList where validUntil is null
+        defaultTrainingShouldNotBeFound("validUntil.specified=false");
+    }
+
+    @Test
+    @Transactional
+    public void getAllTrainingsByIsOfficialIsEqualToSomething() throws Exception {
+        // Initialize the database
+        trainingRepository.saveAndFlush(training);
+
+        // Get all the trainingList where isOfficial equals to DEFAULT_IS_OFFICIAL
+        defaultTrainingShouldBeFound("isOfficial.equals=" + DEFAULT_IS_OFFICIAL);
+
+        // Get all the trainingList where isOfficial equals to UPDATED_IS_OFFICIAL
+        defaultTrainingShouldNotBeFound("isOfficial.equals=" + UPDATED_IS_OFFICIAL);
+    }
+
+    @Test
+    @Transactional
+    public void getAllTrainingsByIsOfficialIsInShouldWork() throws Exception {
+        // Initialize the database
+        trainingRepository.saveAndFlush(training);
+
+        // Get all the trainingList where isOfficial in DEFAULT_IS_OFFICIAL or UPDATED_IS_OFFICIAL
+        defaultTrainingShouldBeFound("isOfficial.in=" + DEFAULT_IS_OFFICIAL + "," + UPDATED_IS_OFFICIAL);
+
+        // Get all the trainingList where isOfficial equals to UPDATED_IS_OFFICIAL
+        defaultTrainingShouldNotBeFound("isOfficial.in=" + UPDATED_IS_OFFICIAL);
+    }
+
+    @Test
+    @Transactional
+    public void getAllTrainingsByIsOfficialIsNullOrNotNull() throws Exception {
+        // Initialize the database
+        trainingRepository.saveAndFlush(training);
+
+        // Get all the trainingList where isOfficial is not null
+        defaultTrainingShouldBeFound("isOfficial.specified=true");
+
+        // Get all the trainingList where isOfficial is null
+        defaultTrainingShouldNotBeFound("isOfficial.specified=false");
+    }
+
+    @Test
+    @Transactional
+    public void getAllTrainingsBySkillIsEqualToSomething() throws Exception {
+        // Initialize the database
+        Skill skill = SkillResourceIntTest.createEntity(em);
+        em.persist(skill);
+        em.flush();
+        training.addSkill(skill);
+        trainingRepository.saveAndFlush(training);
+        Long skillId = skill.getId();
+
+        // Get all the trainingList where skill equals to skillId
+        defaultTrainingShouldBeFound("skillId.equals=" + skillId);
+
+        // Get all the trainingList where skill equals to skillId + 1
+        defaultTrainingShouldNotBeFound("skillId.equals=" + (skillId + 1));
+    }
+
+    /**
+     * Executes the search, and checks that the default entity is returned
+     */
+    private void defaultTrainingShouldBeFound(String filter) throws Exception {
+        restTrainingMockMvc.perform(get("/api/trainings?sort=id,desc&" + filter))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+            .andExpect(jsonPath("$.[*].id").value(hasItem(training.getId().intValue())))
+            .andExpect(jsonPath("$.[*].title").value(hasItem(DEFAULT_TITLE.toString())))
+            .andExpect(jsonPath("$.[*].description").value(hasItem(DEFAULT_DESCRIPTION.toString())))
+            .andExpect(jsonPath("$.[*].contactPerson").value(hasItem(DEFAULT_CONTACT_PERSON.toString())))
+            .andExpect(jsonPath("$.[*].link").value(hasItem(DEFAULT_LINK.toString())))
+            .andExpect(jsonPath("$.[*].validUntil").value(hasItem(DEFAULT_VALID_UNTIL.toString())))
+            .andExpect(jsonPath("$.[*].isOfficial").value(hasItem(DEFAULT_IS_OFFICIAL.booleanValue())));
+    }
+
+    /**
+     * Executes the search, and checks that the default entity is not returned
+     */
+    private void defaultTrainingShouldNotBeFound(String filter) throws Exception {
+        restTrainingMockMvc.perform(get("/api/trainings?sort=id,desc&" + filter))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+            .andExpect(jsonPath("$").isArray())
+            .andExpect(jsonPath("$").isEmpty());
+    }
+
+
+    @Test
+    @Transactional
+    public void getNonExistingTraining() throws Exception {
+        // Get the training
+        restTrainingMockMvc.perform(get("/api/trainings/{id}", Long.MAX_VALUE))
+            .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @Transactional
+    public void updateTraining() throws Exception {
+        // Initialize the database
+        trainingRepository.saveAndFlush(training);
+
+        int databaseSizeBeforeUpdate = trainingRepository.findAll().size();
+
+        // Update the training
+        Training updatedTraining = trainingRepository.findById(training.getId()).get();
+        // Disconnect from session so that the updates on updatedTraining are not directly saved in db
+        em.detach(updatedTraining);
+        updatedTraining
+            .title(UPDATED_TITLE)
+            .description(UPDATED_DESCRIPTION)
+            .contactPerson(UPDATED_CONTACT_PERSON)
+            .link(UPDATED_LINK)
+            .validUntil(UPDATED_VALID_UNTIL)
+            .isOfficial(UPDATED_IS_OFFICIAL);
+        TrainingDTO trainingDTO = trainingMapper.toDto(updatedTraining);
+
+        restTrainingMockMvc.perform(put("/api/trainings")
+            .contentType(TestUtil.APPLICATION_JSON_UTF8)
+            .content(TestUtil.convertObjectToJsonBytes(trainingDTO)))
+            .andExpect(status().isOk());
+
+        // Validate the Training in the database
+        List<Training> trainingList = trainingRepository.findAll();
+        assertThat(trainingList).hasSize(databaseSizeBeforeUpdate);
+        Training testTraining = trainingList.get(trainingList.size() - 1);
+        assertThat(testTraining.getTitle()).isEqualTo(UPDATED_TITLE);
+        assertThat(testTraining.getDescription()).isEqualTo(UPDATED_DESCRIPTION);
+        assertThat(testTraining.getContactPerson()).isEqualTo(UPDATED_CONTACT_PERSON);
+        assertThat(testTraining.getLink()).isEqualTo(UPDATED_LINK);
+        assertThat(testTraining.getValidUntil()).isEqualTo(UPDATED_VALID_UNTIL);
+        assertThat(testTraining.isIsOfficial()).isEqualTo(UPDATED_IS_OFFICIAL);
+    }
+
+    @Test
+    @Transactional
+    public void updateNonExistingTraining() throws Exception {
+        int databaseSizeBeforeUpdate = trainingRepository.findAll().size();
+
+        // Create the Training
+        TrainingDTO trainingDTO = trainingMapper.toDto(training);
+
+        // If the entity doesn't have an ID, it will be created instead of just being updated
+        restTrainingMockMvc.perform(put("/api/trainings")
+            .contentType(TestUtil.APPLICATION_JSON_UTF8)
+            .content(TestUtil.convertObjectToJsonBytes(trainingDTO)))
+            .andExpect(status().isCreated());
+
+        // Validate the Training in the database
+        List<Training> trainingList = trainingRepository.findAll();
+        assertThat(trainingList).hasSize(databaseSizeBeforeUpdate + 1);
+    }
+
+    @Test
+    @Transactional
+    public void deleteTraining() throws Exception {
+        // Initialize the database
+        trainingRepository.saveAndFlush(training);
+
+        int databaseSizeBeforeDelete = trainingRepository.findAll().size();
+
+        // Get the training
+        restTrainingMockMvc.perform(delete("/api/trainings/{id}", training.getId())
+            .accept(TestUtil.APPLICATION_JSON_UTF8))
+            .andExpect(status().isOk());
+
+        // Validate the database is empty
+        List<Training> trainingList = trainingRepository.findAll();
+        assertThat(trainingList).hasSize(databaseSizeBeforeDelete - 1);
+    }
+
+    @Test
+    @Transactional
+    public void equalsVerifier() throws Exception {
+        TestUtil.equalsVerifier(Training.class);
+        Training training1 = new Training();
+        training1.setId(1L);
+        Training training2 = new Training();
+        training2.setId(training1.getId());
+        assertThat(training1).isEqualTo(training2);
+        training2.setId(2L);
+        assertThat(training1).isNotEqualTo(training2);
+        training1.setId(null);
+        assertThat(training1).isNotEqualTo(training2);
+    }
+
+    @Test
+    @Transactional
+    public void dtoEqualsVerifier() throws Exception {
+        TestUtil.equalsVerifier(TrainingDTO.class);
+        TrainingDTO trainingDTO1 = new TrainingDTO();
+        trainingDTO1.setId(1L);
+        TrainingDTO trainingDTO2 = new TrainingDTO();
+        assertThat(trainingDTO1).isNotEqualTo(trainingDTO2);
+        trainingDTO2.setId(trainingDTO1.getId());
+        assertThat(trainingDTO1).isEqualTo(trainingDTO2);
+        trainingDTO2.setId(2L);
+        assertThat(trainingDTO1).isNotEqualTo(trainingDTO2);
+        trainingDTO1.setId(null);
+        assertThat(trainingDTO1).isNotEqualTo(trainingDTO2);
+    }
+
+    @Test
+    @Transactional
+    public void testEntityFromId() {
+        assertThat(trainingMapper.fromId(42L).getId()).isEqualTo(42);
+        assertThat(trainingMapper.fromId(null)).isNull();
+    }
+}

--- a/src/test/javascript/spec/app/entities/skill/skill-update.component.spec.ts
+++ b/src/test/javascript/spec/app/entities/skill/skill-update.component.spec.ts
@@ -8,6 +8,8 @@ import { SkillUpdateComponent } from 'app/entities/skill/skill-update.component'
 import { SkillService } from 'app/entities/skill/skill.service';
 import { Skill } from 'app/shared/model/skill.model';
 
+import { TrainingService } from 'app/entities/training';
+
 describe('Component Tests', () => {
     describe('Skill Management Update Component', () => {
         let comp: SkillUpdateComponent;
@@ -18,7 +20,7 @@ describe('Component Tests', () => {
             TestBed.configureTestingModule({
                 imports: [TeamdojoTestModule],
                 declarations: [SkillUpdateComponent],
-                providers: [SkillService]
+                providers: [TrainingService, SkillService]
             })
                 .overrideTemplate(SkillUpdateComponent, '')
                 .compileComponents();

--- a/src/test/javascript/spec/app/entities/training/training-delete-dialog.component.spec.ts
+++ b/src/test/javascript/spec/app/entities/training/training-delete-dialog.component.spec.ts
@@ -1,0 +1,56 @@
+/* tslint:disable max-line-length */
+import { ComponentFixture, TestBed, inject, fakeAsync, tick } from '@angular/core/testing';
+import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
+import { Observable } from 'rxjs/Observable';
+import { JhiEventManager } from 'ng-jhipster';
+
+import { TeamdojoTestModule } from '../../../test.module';
+import { TrainingDeleteDialogComponent } from 'app/entities/training/training-delete-dialog.component';
+import { TrainingService } from 'app/entities/training/training.service';
+
+describe('Component Tests', () => {
+    describe('Training Management Delete Component', () => {
+        let comp: TrainingDeleteDialogComponent;
+        let fixture: ComponentFixture<TrainingDeleteDialogComponent>;
+        let service: TrainingService;
+        let mockEventManager: any;
+        let mockActiveModal: any;
+
+        beforeEach(() => {
+            TestBed.configureTestingModule({
+                imports: [TeamdojoTestModule],
+                declarations: [TrainingDeleteDialogComponent],
+                providers: [TrainingService]
+            })
+                .overrideTemplate(TrainingDeleteDialogComponent, '')
+                .compileComponents();
+            fixture = TestBed.createComponent(TrainingDeleteDialogComponent);
+            comp = fixture.componentInstance;
+            service = fixture.debugElement.injector.get(TrainingService);
+            mockEventManager = fixture.debugElement.injector.get(JhiEventManager);
+            mockActiveModal = fixture.debugElement.injector.get(NgbActiveModal);
+        });
+
+        describe('confirmDelete', () => {
+            it(
+                'Should call delete service on confirmDelete',
+                inject(
+                    [],
+                    fakeAsync(() => {
+                        // GIVEN
+                        spyOn(service, 'delete').and.returnValue(Observable.of({}));
+
+                        // WHEN
+                        comp.confirmDelete(123);
+                        tick();
+
+                        // THEN
+                        expect(service.delete).toHaveBeenCalledWith(123);
+                        expect(mockActiveModal.dismissSpy).toHaveBeenCalled();
+                        expect(mockEventManager.broadcastSpy).toHaveBeenCalled();
+                    })
+                )
+            );
+        });
+    });
+});

--- a/src/test/javascript/spec/app/entities/training/training-detail.component.spec.ts
+++ b/src/test/javascript/spec/app/entities/training/training-detail.component.spec.ts
@@ -1,0 +1,40 @@
+/* tslint:disable max-line-length */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute } from '@angular/router';
+import { of } from 'rxjs/observable/of';
+
+import { TeamdojoTestModule } from '../../../test.module';
+import { TrainingDetailComponent } from 'app/entities/training/training-detail.component';
+import { Training } from 'app/shared/model/training.model';
+
+describe('Component Tests', () => {
+    describe('Training Management Detail Component', () => {
+        let comp: TrainingDetailComponent;
+        let fixture: ComponentFixture<TrainingDetailComponent>;
+        const route = ({ data: of({ training: new Training(123) }) } as any) as ActivatedRoute;
+
+        beforeEach(() => {
+            TestBed.configureTestingModule({
+                imports: [TeamdojoTestModule],
+                declarations: [TrainingDetailComponent],
+                providers: [{ provide: ActivatedRoute, useValue: route }]
+            })
+                .overrideTemplate(TrainingDetailComponent, '')
+                .compileComponents();
+            fixture = TestBed.createComponent(TrainingDetailComponent);
+            comp = fixture.componentInstance;
+        });
+
+        describe('OnInit', () => {
+            it('Should call load all on init', () => {
+                // GIVEN
+
+                // WHEN
+                comp.ngOnInit();
+
+                // THEN
+                expect(comp.training).toEqual(jasmine.objectContaining({ id: 123 }));
+            });
+        });
+    });
+});

--- a/src/test/javascript/spec/app/entities/training/training-update.component.spec.ts
+++ b/src/test/javascript/spec/app/entities/training/training-update.component.spec.ts
@@ -1,0 +1,69 @@
+/* tslint:disable max-line-length */
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { HttpResponse } from '@angular/common/http';
+import { Observable } from 'rxjs/Observable';
+
+import { TeamdojoTestModule } from '../../../test.module';
+import { TrainingUpdateComponent } from 'app/entities/training/training-update.component';
+import { TrainingService } from 'app/entities/training/training.service';
+import { Training } from 'app/shared/model/training.model';
+
+import { SkillService } from 'app/entities/skill';
+
+describe('Component Tests', () => {
+    describe('Training Management Update Component', () => {
+        let comp: TrainingUpdateComponent;
+        let fixture: ComponentFixture<TrainingUpdateComponent>;
+        let service: TrainingService;
+
+        beforeEach(() => {
+            TestBed.configureTestingModule({
+                imports: [TeamdojoTestModule],
+                declarations: [TrainingUpdateComponent],
+                providers: [SkillService, TrainingService]
+            })
+                .overrideTemplate(TrainingUpdateComponent, '')
+                .compileComponents();
+
+            fixture = TestBed.createComponent(TrainingUpdateComponent);
+            comp = fixture.componentInstance;
+            service = fixture.debugElement.injector.get(TrainingService);
+        });
+
+        describe('save', () => {
+            it(
+                'Should call update service on save for existing entity',
+                fakeAsync(() => {
+                    // GIVEN
+                    const entity = new Training(123);
+                    spyOn(service, 'update').and.returnValue(Observable.of(new HttpResponse({ body: entity })));
+                    comp.training = entity;
+                    // WHEN
+                    comp.save();
+                    tick(); // simulate async
+
+                    // THEN
+                    expect(service.update).toHaveBeenCalledWith(entity);
+                    expect(comp.isSaving).toEqual(false);
+                })
+            );
+
+            it(
+                'Should call create service on save for new entity',
+                fakeAsync(() => {
+                    // GIVEN
+                    const entity = new Training();
+                    spyOn(service, 'create').and.returnValue(Observable.of(new HttpResponse({ body: entity })));
+                    comp.training = entity;
+                    // WHEN
+                    comp.save();
+                    tick(); // simulate async
+
+                    // THEN
+                    expect(service.create).toHaveBeenCalledWith(entity);
+                    expect(comp.isSaving).toEqual(false);
+                })
+            );
+        });
+    });
+});

--- a/src/test/javascript/spec/app/entities/training/training.component.spec.ts
+++ b/src/test/javascript/spec/app/entities/training/training.component.spec.ts
@@ -1,0 +1,129 @@
+/* tslint:disable max-line-length */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Observable } from 'rxjs/Observable';
+import { HttpHeaders, HttpResponse } from '@angular/common/http';
+import { ActivatedRoute, Data } from '@angular/router';
+
+import { TeamdojoTestModule } from '../../../test.module';
+import { TrainingComponent } from 'app/entities/training/training.component';
+import { TrainingService } from 'app/entities/training/training.service';
+import { Training } from 'app/shared/model/training.model';
+
+describe('Component Tests', () => {
+    describe('Training Management Component', () => {
+        let comp: TrainingComponent;
+        let fixture: ComponentFixture<TrainingComponent>;
+        let service: TrainingService;
+
+        beforeEach(() => {
+            TestBed.configureTestingModule({
+                imports: [TeamdojoTestModule],
+                declarations: [TrainingComponent],
+                providers: [
+                    TrainingService,
+                    {
+                        provide: ActivatedRoute,
+                        useValue: {
+                            data: {
+                                subscribe: (fn: (value: Data) => void) =>
+                                    fn({
+                                        pagingParams: {
+                                            predicate: 'id',
+                                            reverse: false,
+                                            page: 0
+                                        }
+                                    })
+                            }
+                        }
+                    }
+                ]
+            })
+                .overrideTemplate(TrainingComponent, '')
+                .compileComponents();
+
+            fixture = TestBed.createComponent(TrainingComponent);
+            comp = fixture.componentInstance;
+            service = fixture.debugElement.injector.get(TrainingService);
+        });
+
+        it('Should call load all on init', () => {
+            // GIVEN
+            const headers = new HttpHeaders().append('link', 'link;link');
+            spyOn(service, 'query').and.returnValue(
+                Observable.of(
+                    new HttpResponse({
+                        body: [new Training(123)],
+                        headers
+                    })
+                )
+            );
+
+            // WHEN
+            comp.ngOnInit();
+
+            // THEN
+            expect(service.query).toHaveBeenCalled();
+            expect(comp.trainings[0]).toEqual(jasmine.objectContaining({ id: 123 }));
+        });
+
+        it('should load a page', () => {
+            // GIVEN
+            const headers = new HttpHeaders().append('link', 'link;link');
+            spyOn(service, 'query').and.returnValue(
+                Observable.of(
+                    new HttpResponse({
+                        body: [new Training(123)],
+                        headers
+                    })
+                )
+            );
+
+            // WHEN
+            comp.loadPage(1);
+
+            // THEN
+            expect(service.query).toHaveBeenCalled();
+            expect(comp.trainings[0]).toEqual(jasmine.objectContaining({ id: 123 }));
+        });
+
+        it('should re-initialize the page', () => {
+            // GIVEN
+            const headers = new HttpHeaders().append('link', 'link;link');
+            spyOn(service, 'query').and.returnValue(
+                Observable.of(
+                    new HttpResponse({
+                        body: [new Training(123)],
+                        headers
+                    })
+                )
+            );
+
+            // WHEN
+            comp.loadPage(1);
+            comp.reset();
+
+            // THEN
+            expect(comp.page).toEqual(0);
+            expect(service.query).toHaveBeenCalledTimes(2);
+            expect(comp.trainings[0]).toEqual(jasmine.objectContaining({ id: 123 }));
+        });
+        it('should calculate the sort attribute for an id', () => {
+            // WHEN
+            const result = comp.sort();
+
+            // THEN
+            expect(result).toEqual(['id,asc']);
+        });
+
+        it('should calculate the sort attribute for a non-id attribute', () => {
+            // GIVEN
+            comp.predicate = 'name';
+
+            // WHEN
+            const result = comp.sort();
+
+            // THEN
+            expect(result).toEqual(['name,asc', 'id']);
+        });
+    });
+});

--- a/src/test/javascript/spec/app/entities/training/training.service.spec.ts
+++ b/src/test/javascript/spec/app/entities/training/training.service.spec.ts
@@ -1,0 +1,96 @@
+/* tslint:disable max-line-length */
+import { TestBed, getTestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { TrainingService } from 'app/entities/training/training.service';
+import { Training } from 'app/shared/model/training.model';
+import { SERVER_API_URL } from 'app/app.constants';
+
+describe('Service Tests', () => {
+    describe('Training Service', () => {
+        let injector: TestBed;
+        let service: TrainingService;
+        let httpMock: HttpTestingController;
+
+        beforeEach(() => {
+            TestBed.configureTestingModule({
+                imports: [HttpClientTestingModule],
+                providers: [TrainingService]
+            });
+            injector = getTestBed();
+            service = injector.get(TrainingService);
+            httpMock = injector.get(HttpTestingController);
+        });
+
+        describe('Service methods', () => {
+            it('should call correct URL', () => {
+                service.find(123).subscribe(() => {});
+
+                const req = httpMock.expectOne({ method: 'GET' });
+
+                const resourceUrl = SERVER_API_URL + 'api/trainings';
+                expect(req.request.url).toEqual(resourceUrl + '/' + 123);
+            });
+
+            it('should create a Training', () => {
+                service.create(new Training(null)).subscribe(received => {
+                    expect(received.body.id).toEqual(null);
+                });
+
+                const req = httpMock.expectOne({ method: 'POST' });
+                req.flush({ id: null });
+            });
+
+            it('should update a Training', () => {
+                service.update(new Training(123)).subscribe(received => {
+                    expect(received.body.id).toEqual(123);
+                });
+
+                const req = httpMock.expectOne({ method: 'PUT' });
+                req.flush({ id: 123 });
+            });
+
+            it('should return a Training', () => {
+                service.find(123).subscribe(received => {
+                    expect(received.body.id).toEqual(123);
+                });
+
+                const req = httpMock.expectOne({ method: 'GET' });
+                req.flush({ id: 123 });
+            });
+
+            it('should return a list of Training', () => {
+                service.query(null).subscribe(received => {
+                    expect(received.body[0].id).toEqual(123);
+                });
+
+                const req = httpMock.expectOne({ method: 'GET' });
+                req.flush([new Training(123)]);
+            });
+
+            it('should delete a Training', () => {
+                service.delete(123).subscribe(received => {
+                    expect(received.url).toContain('/' + 123);
+                });
+
+                const req = httpMock.expectOne({ method: 'DELETE' });
+                req.flush(null);
+            });
+
+            it('should propagate not found response', () => {
+                service.find(123).subscribe(null, (_error: any) => {
+                    expect(_error.status).toEqual(404);
+                });
+
+                const req = httpMock.expectOne({ method: 'GET' });
+                req.flush('Invalid request parameters', {
+                    status: 404,
+                    statusText: 'Bad Request'
+                });
+            });
+        });
+
+        afterEach(() => {
+            httpMock.verify();
+        });
+    });
+});


### PR DESCRIPTION
Use JHipster to generate code for the new entity `training` and include it for display in associated skills. This PR is the first of a series regarding different features of managing and displaying trainings.