### PR TITLE
[EDO-231] Persist filter inputs for entities across page load 

### DIFF
--- a/src/main/webapp/app/entities/level-skill/level-skill.component.html
+++ b/src/main/webapp/app/entities/level-skill/level-skill.component.html
@@ -22,7 +22,7 @@
             <th></th>
             </tr>
 
-            <tr jhi-table-filter [fields]="[
+            <tr jhi-table-filter entityName="LevelSkill" [fields]="[
                 {name: 'id', filter: true, operator: 'equals'},
                 {name: 'skillTitle', filter: true, operator: 'contains'},
                 {name: 'levelName', filter: true, operator: 'contains'}

--- a/src/main/webapp/app/entities/skill/skill.component.html
+++ b/src/main/webapp/app/entities/skill/skill.component.html
@@ -27,7 +27,7 @@
             <th></th>
             </tr>
 
-            <tr jhi-table-filter [fields]="[
+            <tr jhi-table-filter entityName="Skill" [fields]="[
                 {name: 'id', filter: true, operator: 'equals'},
                 {name: 'title', filter: true},
                 {name: 'description', filter: true},

--- a/src/main/webapp/app/shared/table-filter/table-filter.component.html
+++ b/src/main/webapp/app/shared/table-filter/table-filter.component.html
@@ -1,6 +1,7 @@
 <th *ngFor="let field of fields">
     <div *ngIf="field.filter" class="filter-field">
         <input type="text" class="form-control" [(ngModel)]="filterInputs[field.name]" (ngModelChange)="updateFilters()">
-        <span class="filter-icon fa fa-search"></span>
+        <span *ngIf="filterInputs[field.name] === ''" class="filter-icon fa fa-search"></span>
+        <span *ngIf="filterInputs[field.name] !== ''" class="clear-icon fa fa-times-circle" (click)="clearField(field)"></span>
     </div>
 </th>

--- a/src/main/webapp/app/shared/table-filter/table-filter.component.html
+++ b/src/main/webapp/app/shared/table-filter/table-filter.component.html
@@ -1,6 +1,6 @@
 <th *ngFor="let field of fields">
     <div *ngIf="field.filter" class="filter-field">
-        <input type="text" class="form-control" [(ngModel)]="filterInputs[field.name]" (ngModelChange)="updateFilter()">
+        <input type="text" class="form-control" [(ngModel)]="filterInputs[field.name]" (ngModelChange)="updateFilters()">
         <span class="filter-icon fa fa-search"></span>
     </div>
 </th>

--- a/src/main/webapp/app/shared/table-filter/table-filter.component.ts
+++ b/src/main/webapp/app/shared/table-filter/table-filter.component.ts
@@ -77,4 +77,9 @@ export class TableFilterComponent implements OnInit {
     saveFilters() {
         localStorage.setItem(`TABLE_FILTER_${this.entityName}`, JSON.stringify(this.filterInputs));
     }
+
+    clearField(field: TableField) {
+        this.filterInputs[field.name] = '';
+        this.updateFilters();
+    }
 }

--- a/src/main/webapp/app/shared/table-filter/table-filter.component.ts
+++ b/src/main/webapp/app/shared/table-filter/table-filter.component.ts
@@ -34,7 +34,6 @@ export class TableFilterComponent implements OnInit {
 
     private filterOperators: { [k: string]: string } = {};
 
-    // constructor(private storage: Storage) {
     constructor() {
         this.filterChanged.debounceTime(500).subscribe(query => this.onFilterChanged.emit(query));
     }

--- a/src/main/webapp/app/shared/table-filter/table-filter.scss
+++ b/src/main/webapp/app/shared/table-filter/table-filter.scss
@@ -1,10 +1,14 @@
 .filter-field {
     position: relative;
+    .clear-icon,
     .filter-icon {
         right: 0.4rem;
         top: 0.6rem;
         position: absolute;
         color: #bbb;
+    }
+    .clear-icon {
+        cursor: pointer;
     }
     input {
         padding-right: 1.5rem;


### PR DESCRIPTION
This is an extension to #25 to persist filter inputs in localStorage, which enables a better user experience for the admin while managing entities.

localStorage is used directly without dependency injection as it avoids adding complexity to the code.