### PR TITLE
[EDO-209] Version in footer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,3 @@
-import org.ajoberstar.gradle.git.release.opinion.Strategies
-import org.ajoberstar.grgit.Grgit
 import org.gradle.internal.os.OperatingSystem
 
 buildscript {
@@ -25,9 +23,9 @@ plugins {
     id "net.ltgt.apt" version "0.19"
     id "io.spring.dependency-management" version "1.0.6.RELEASE"
     id "com.moowork.node" version "1.2.0"
-    id 'org.liquibase.gradle' version '2.0.1'
+    id "org.liquibase.gradle" version "2.0.1"
     //jhipster-needle-gradle-plugins - JHipster will add additional gradle plugins here
-    id 'org.ajoberstar.release-opinion' version '1.7.2'
+    id "org.ajoberstar.reckon" version "0.9.0"
 }
 
 apply plugin: 'java'
@@ -43,7 +41,8 @@ apply plugin: 'propdeps'
 apply plugin: 'com.moowork.node'
 apply plugin: 'io.spring.dependency-management'
 apply plugin: 'idea'
-apply plugin: "com.gorylenko.gradle-git-properties"
+apply plugin: 'com.gorylenko.gradle-git-properties'
+apply plugin: 'org.ajoberstar.reckon'
 
 idea {
   module {
@@ -61,7 +60,6 @@ dependencyManagement {
 defaultTasks 'bootRun'
 
 group = 'de.otto.teamdojo'
-version = '0.0.1-SNAPSHOT'
 
 description = ''
 
@@ -74,18 +72,13 @@ war {
     enabled = true
     extension = 'war.original'
 }
-
 springBoot {
     mainClassName = 'de.otto.teamdojo.TeamdojoApp'
 }
 
-release {
-    versionStrategy Strategies.FINAL
-    defaultVersionStrategy Strategies.SNAPSHOT
-    grgit = Grgit.open(currentDir: project.file('.'))
-    tagStrategy {
-        generateMessage = { version -> "Version $project.version" }
-    }
+reckon {
+    scopeFromProp()
+    snapshotFromProp()
 }
 
 if (OperatingSystem.current().isWindows()) {

--- a/build.gradle
+++ b/build.gradle
@@ -81,6 +81,12 @@ reckon {
     stageFromProp('rc')
 }
 
+task printVersion {
+    doLast {
+        println project.version
+    }
+}
+
 if (OperatingSystem.current().isWindows()) {
     // https://stackoverflow.com/questions/40037487/the-filename-or-extension-is-too-long-error-using-gradle
     task classpathJar(type: Jar) {

--- a/build.gradle
+++ b/build.gradle
@@ -78,7 +78,7 @@ springBoot {
 
 reckon {
     scopeFromProp()
-    snapshotFromProp()
+    stageFromProp('rc')
 }
 
 if (OperatingSystem.current().isWindows()) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -51,3 +51,5 @@ liquibaseTaskPrefix=liquibase
 ## un comment the below line to enable the selective mode
 
 #org.gradle.configureondemand=true
+
+reckon.scope=patch

--- a/gradle/profile_prod.gradle
+++ b/gradle/profile_prod.gradle
@@ -29,7 +29,7 @@ task webpack_test(type: NpmTask, dependsOn: 'npm_install') {
 
 task webpack(type: NpmTask, dependsOn: 'npm_install') {
     args = ["run", "webpack:prod"]
-    environment = [ "VERSION": project.version ]
+    environment = [ "TEAMDOJO_BUILD_VERSION": project.version ]
 }
 
 task copyIntoStatic (type: Copy) {

--- a/gradle/profile_prod.gradle
+++ b/gradle/profile_prod.gradle
@@ -29,6 +29,7 @@ task webpack_test(type: NpmTask, dependsOn: 'npm_install') {
 
 task webpack(type: NpmTask, dependsOn: 'npm_install') {
     args = ["run", "webpack:prod"]
+    environment = [ "VERSION": project.version ]
 }
 
 task copyIntoStatic (type: Copy) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5450,14 +5450,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5472,20 +5470,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5602,8 +5597,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5615,7 +5609,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5630,7 +5623,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5638,14 +5630,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5664,7 +5654,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5745,8 +5734,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5758,7 +5746,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5880,7 +5867,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/src/main/webapp/app/layouts/footer/footer.component.ts
+++ b/src/main/webapp/app/layouts/footer/footer.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { VERSION } from 'app/app.constants';
+import { VERSION, BUILD_TIMESTAMP } from 'app/app.constants';
 
 @Component({
     selector: 'jhi-footer',
@@ -10,6 +10,6 @@ export class FooterComponent {
     version: string;
 
     constructor() {
-        this.version = VERSION ? 'v' + VERSION : '';
+        this.version = (VERSION ? `v${VERSION}` : '') + `.${BUILD_TIMESTAMP}`;
     }
 }

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -6,14 +6,6 @@ const MergeJsonWebpackPlugin = require("merge-jsons-webpack-plugin");
 
 const utils = require('./utils.js');
 
-const VERSION_ARG_NAME = "--version=";
-const getVersion = () => {
-    let version = process.argv.find((e) => {
-        return e.startsWith(VERSION_ARG_NAME);
-    });
-    return version ?  version.substring(VERSION_ARG_NAME.length) : "_DEV";
-};
-
 module.exports = (options) => ({
     resolve: {
         extensions: ['.ts', '.js'],
@@ -65,7 +57,7 @@ module.exports = (options) => ({
             'process.env': {
                 NODE_ENV: `'${options.env}'`,
                 BUILD_TIMESTAMP: `'${new Date().getTime()}'`,
-                VERSION: `'${getVersion()}'`,
+                VERSION: process.env["VERSION"] || "_DEV",
                 DEBUG_INFO_ENABLED: options.env === 'development',
                 // The root URL for API calls, ending with a '/' - for example: `"https://www.jhipster.tech:8081/myservice/"`.
                 // If this URL is left empty (""), then it will be relative to the current context.

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -80,8 +80,8 @@ module.exports = (options) => ({
         new MergeJsonWebpackPlugin({
             output: {
                 groupBy: [
-                    { pattern: "./src/main/webapp/i18n/de/*.json", fileName: "./i18n/de.json" }, //for SLAB usage!!!
-                    { pattern: "./src/main/webapp/i18n/en/*.json", fileName: "./i18n/en.json" } //for SLAB usage!!!
+                    { pattern: "./src/main/webapp/i18n/de/*.json", fileName: "./i18n/de.json" },
+                    { pattern: "./src/main/webapp/i18n/en/*.json", fileName: "./i18n/en.json" }
                     // jhipster-needle-i18n-language-webpack - JHipster will add/remove languages in this array
                 ]
             }

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -56,7 +56,7 @@ module.exports = (options) => ({
         new webpack.DefinePlugin({
             'process.env': {
                 NODE_ENV: `'${options.env}'`,
-                BUILD_TIMESTAMP: `'${new Date().getTime()}'`,
+                BUILD_TIMESTAMP: `'${new Date().toISOString()}'`,
                 VERSION: process.env["VERSION"] || "_DEV",
                 DEBUG_INFO_ENABLED: options.env === 'development',
                 // The root URL for API calls, ending with a '/' - for example: `"https://www.jhipster.tech:8081/myservice/"`.

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -57,7 +57,7 @@ module.exports = (options) => ({
             'process.env': {
                 NODE_ENV: `'${options.env}'`,
                 BUILD_TIMESTAMP: `'${new Date().toISOString()}'`,
-                VERSION: `'${process.env['VERSION'] || '_DEV'}'`,
+                VERSION: `'${process.env['TEAMDOJO_BUILD_VERSION'] || '_DEV'}'`,
                 DEBUG_INFO_ENABLED: options.env === 'development',
                 // The root URL for API calls, ending with a '/' - for example: `"https://www.jhipster.tech:8081/myservice/"`.
                 // If this URL is left empty (""), then it will be relative to the current context.

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -57,7 +57,7 @@ module.exports = (options) => ({
             'process.env': {
                 NODE_ENV: `'${options.env}'`,
                 BUILD_TIMESTAMP: `'${new Date().toISOString()}'`,
-                VERSION: process.env["VERSION"] || "_DEV",
+                VERSION: `'${process.env['VERSION'] || '_DEV'}'`,
                 DEBUG_INFO_ENABLED: options.env === 'development',
                 // The root URL for API calls, ending with a '/' - for example: `"https://www.jhipster.tech:8081/myservice/"`.
                 // If this URL is left empty (""), then it will be relative to the current context.


### PR DESCRIPTION
We lost the capability to display the version tag in the app's footer. This PR fixes it. The proposed release strategy is incrementing patch versions following semver automatically and incrementing major/minor versions manually by pushing git tags. For more details see https://github.com/ajoberstar/reckon

We will no longer use the suffix `-SNAPSHOT`, instead the version will look like this: `0.10.1-rc.0.1+ef037c3`, whereas `rc` is a placeholder for a stage that we do not need at the moment. Our `prod` and `int` Docker images should remain one and the same.

A new Gradle task is added to retrieve the current version easily: `./gradlew printVersion`.
Our CI job reads the version property by executing Gradle to tag Docker images. Before this is merged, we have to make the adjustment accordingly and take care of illegal characters in the reckoned Docker tag (I expect an error regarding the `+` ).