### PR TITLE
EDO-244 configure number of required confirmations

### DIFF
--- a/.jhipster/Organization.json
+++ b/.jhipster/Organization.json
@@ -31,12 +31,22 @@
             ],
             "fieldValidateRulesMaxlength": 255,
             "fieldValidateRulesPattern": "^(?:http(s)?://)?[\\w.-]+(?:\\.[\\w\\.-]+)+[\\w\\-\\._~:/?#\\[\\]@!\\$&'\\(\\)\\*\\+,;=.]+$"
+        },
+        {
+            "fieldName": "countOfConfirmations",
+            "fieldType": "Integer",
+            "fieldValidateRules": [
+                "min"
+            ],
+            "fieldValidateRulesMin": 0
         }
     ],
     "changelogDate": "20180517074753",
     "dto": "mapstruct",
+    "searchEngine": false,
     "service": "serviceImpl",
     "entityTableName": "organization",
+    "databaseType": "sql",
     "jpaMetamodelFiltering": false,
     "pagination": "no"
 }

--- a/src/main/java/de/otto/teamdojo/domain/Organization.java
+++ b/src/main/java/de/otto/teamdojo/domain/Organization.java
@@ -44,6 +44,10 @@ public class Organization implements Serializable {
     @Column(name = "mattermost_url", length = 255)
     private String mattermostUrl;
 
+    @Min(value = 0)
+    @Column(name = "count_of_confirmations")
+    private Integer countOfConfirmations;
+
     // jhipster-needle-entity-add-field - JHipster will add fields here, do not remove
     public Long getId() {
         return id;
@@ -96,13 +100,26 @@ public class Organization implements Serializable {
         return mattermostUrl;
     }
 
+    public Organization mattermostUrl(String mattermostUrl) {
+        this.mattermostUrl = mattermostUrl;
+        return this;
+    }
+
     public void setMattermostUrl(String mattermostUrl) {
         this.mattermostUrl = mattermostUrl;
     }
 
-    public Organization mattermostUrl(String mattermostUrl) {
-        this.mattermostUrl = mattermostUrl;
+    public Integer getCountOfConfirmations() {
+        return countOfConfirmations;
+    }
+
+    public Organization countOfConfirmations(Integer countOfConfirmations) {
+        this.countOfConfirmations = countOfConfirmations;
         return this;
+    }
+
+    public void setCountOfConfirmations(Integer countOfConfirmations) {
+        this.countOfConfirmations = countOfConfirmations;
     }
     // jhipster-needle-entity-add-getters-setters - JHipster will add getters and setters here, do not remove
 
@@ -134,6 +151,7 @@ public class Organization implements Serializable {
             ", levelUpScore=" + getLevelUpScore() +
             ", userMode='" + getUserMode() + "'" +
             ", mattermostUrl='" + getMattermostUrl() + "'" +
+            ", countOfConfirmations=" + getCountOfConfirmations() +
             "}";
     }
 }

--- a/src/main/java/de/otto/teamdojo/service/dto/OrganizationDTO.java
+++ b/src/main/java/de/otto/teamdojo/service/dto/OrganizationDTO.java
@@ -1,5 +1,4 @@
 package de.otto.teamdojo.service.dto;
-
 import javax.validation.constraints.*;
 import java.io.Serializable;
 import java.util.Objects;
@@ -23,6 +22,10 @@ public class OrganizationDTO implements Serializable {
     @Size(max = 255)
     @Pattern(regexp = "^(?:http(s)?://)?[\\w.-]+(?:\\.[\\w\\.-]+)+[\\w\\-\\._~:/?#\\[\\]@!\\$&'\\(\\)\\*\\+,;=.]+$")
     private String mattermostUrl;
+
+    @Min(value = 0)
+    private Integer countOfConfirmations;
+
 
     public Long getId() {
         return id;
@@ -64,6 +67,14 @@ public class OrganizationDTO implements Serializable {
         this.mattermostUrl = mattermostUrl;
     }
 
+    public Integer getCountOfConfirmations() {
+        return countOfConfirmations;
+    }
+
+    public void setCountOfConfirmations(Integer countOfConfirmations) {
+        this.countOfConfirmations = countOfConfirmations;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -93,6 +104,7 @@ public class OrganizationDTO implements Serializable {
             ", levelUpScore=" + getLevelUpScore() +
             ", userMode='" + getUserMode() + "'" +
             ", mattermostUrl='" + getMattermostUrl() + "'" +
+            ", countOfConfirmations=" + getCountOfConfirmations() +
             "}";
     }
 }

--- a/src/main/java/de/otto/teamdojo/service/impl/AchievableSkillServiceImpl.java
+++ b/src/main/java/de/otto/teamdojo/service/impl/AchievableSkillServiceImpl.java
@@ -36,9 +36,6 @@ public class AchievableSkillServiceImpl implements AchievableSkillService {
 
     private static final List<String> ALL_FILTER = Lists.newArrayList("COMPLETE", "INCOMPLETE");
 
-    private static final int REQUIRED_VOTES_FOR_TEAM_MODE = Integer.MIN_VALUE;
-    private static final int REQUIRED_VOTES_FOR_PERSON_MODE = 5;
-
     private final SkillRepository skillRepository;
 
     private final TeamRepository teamRepository;
@@ -98,11 +95,7 @@ public class AchievableSkillServiceImpl implements AchievableSkillService {
         teamSkill.setVoters(achievableSkill.getVoters());
         teamSkill.setIrrelevant(achievableSkill.isIrrelevant());
 
-        int requiredVotes = REQUIRED_VOTES_FOR_TEAM_MODE;
-
-        if (organizationService.getCurrentOrganization().getUserMode().equals(UserMode.PERSON)) {
-            requiredVotes = REQUIRED_VOTES_FOR_PERSON_MODE;
-        }
+        int requiredVotes = organizationService.getCurrentOrganization().getCountOfConfirmations();
 
         if (teamSkill.getVote() >= requiredVotes && teamSkill.getVerifiedAt() == null) {
             teamSkill.setVerifiedAt(Instant.now());

--- a/src/main/java/de/otto/teamdojo/service/impl/ActivityServiceImpl.java
+++ b/src/main/java/de/otto/teamdojo/service/impl/ActivityServiceImpl.java
@@ -125,7 +125,7 @@ public class ActivityServiceImpl implements ActivityService {
 
         String message = team.getName() + " hat den Skill \"" + skill.getTitle() + "\" erlernt!";
 
-        if (organizationService.getCurrentOrganization().getUserMode().equals(UserMode.PERSON)) {
+        if (organizationService.getCurrentOrganization().getCountOfConfirmations() > 0) {
             message += " <" + properties.getFrontend() + "team-skill/" + teamSkill.getId() + "/vote|Traust du das " + team.getName() + " zu?>";
         }
 

--- a/src/main/resources/config/liquibase/changelog/20190227105900_add_count_of_confirmations_to_organization.xml
+++ b/src/main/resources/config/liquibase/changelog/20190227105900_add_count_of_confirmations_to_organization.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<databaseChangeLog
+    xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd
+                        http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+
+    <changeSet id="20190227105900-1" author="mhi">
+        <addColumn tableName="organization">
+            <column name="count_of_confirmations" type="integer">
+                <constraints nullable="true" />
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/master.xml
+++ b/src/main/resources/config/liquibase/master.xml
@@ -45,4 +45,5 @@
     <include file="config/liquibase/changelog/20190205142213_jhipster_update.xml" relativeToChangelogFile="false"/>
 
     <include file="config/liquibase/changelog/20190218115900_add_suggested_by_column_to_training.xml" relativeToChangelogFile="false"/>
+    <include file="config/liquibase/changelog/20190227105900_add_count_of_confirmations_to_organization.xml" relativeToChangelogFile="false"/>
 </databaseChangeLog>

--- a/src/main/webapp/app/entities/entity.module.ts
+++ b/src/main/webapp/app/entities/entity.module.ts
@@ -59,6 +59,10 @@ import { RouterModule } from '@angular/router';
             {
                 path: 'training',
                 loadChildren: './training/training.module#TeamdojoTrainingModule'
+            },
+            {
+                path: 'organization',
+                loadChildren: './organization/organization.module#TeamdojoOrganizationModule'
             }
             /* jhipster-needle-add-entity-route - JHipster will add entity modules routes here */
         ])

--- a/src/main/webapp/app/entities/organization/organization-detail.component.html
+++ b/src/main/webapp/app/entities/organization/organization-detail.component.html
@@ -22,6 +22,10 @@
                 <dd>
                     <span>{{organization.mattermostUrl}}</span>
                 </dd>
+                <dt><span dojoTranslate="teamdojoApp.organization.countOfConfirmations">Count Of Confirmations</span></dt>
+                <dd>
+                    <span>{{organization.countOfConfirmations}}</span>
+                </dd>
             </dl>
 
             <button type="submit"

--- a/src/main/webapp/app/entities/organization/organization-update.component.html
+++ b/src/main/webapp/app/entities/organization/organization-update.component.html
@@ -62,6 +62,21 @@
                         </small>
                     </div>
                 </div>
+                <div class="form-group">
+                    <label class="form-control-label" dojoTranslate="teamdojoApp.organization.countOfConfirmations" for="field_countOfConfirmations">Count Of Confirmations</label>
+                    <input type="number" class="form-control" name="countOfConfirmations" id="field_countOfConfirmations"
+                        [(ngModel)]="organization.countOfConfirmations" min="0" jhiMin="0"/>
+                    <div [hidden]="!(editForm.controls.countOfConfirmations?.dirty && editForm.controls.countOfConfirmations?.invalid)">
+                        <small class="form-text text-danger"
+                            [hidden]="!editForm.controls.countOfConfirmations?.errors?.min" dojoTranslate="entity.validation.min" [translateValues]="{ min: 0 }">
+                            This field should be at least 0.
+                        </small>
+                        <small class="form-text text-danger"
+                            [hidden]="!editForm.controls.countOfConfirmations?.errors?.number" dojoTranslate="entity.validation.number">
+                            This field should be a number.
+                        </small>
+                    </div>
+                </div>
 
             </div>
             <div>

--- a/src/main/webapp/app/entities/organization/organization-update.component.ts
+++ b/src/main/webapp/app/entities/organization/organization-update.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { HttpResponse, HttpErrorResponse } from '@angular/common/http';
 import { Observable } from 'rxjs';
-
+import { filter, map } from 'rxjs/operators';
 import { IOrganization } from 'app/shared/model/organization.model';
 import { OrganizationService } from './organization.service';
 

--- a/src/main/webapp/app/entities/organization/organization.component.html
+++ b/src/main/webapp/app/entities/organization/organization.component.html
@@ -14,11 +14,12 @@
         <table class="table table-striped">
             <thead>
             <tr>
-                <th><span dojoTranslate="teamdojoApp.global.field.id">ID</span></th>
+            <th><span dojoTranslate="teamdojoApp.global.field.id">ID</span></th>
             <th><span dojoTranslate="teamdojoApp.organization.name">Name</span></th>
             <th><span dojoTranslate="teamdojoApp.organization.levelUpScore">Level Up Score</span></th>
-                <th><span dojoTranslate="teamdojoApp.organization.userMode">User Mode</span></th>
-                <th><span dojoTranslate="teamdojoApp.organization.mattermostUrl">Mattermost Url</span></th>
+            <th><span dojoTranslate="teamdojoApp.organization.userMode">User Mode</span></th>
+            <th><span dojoTranslate="teamdojoApp.organization.mattermostUrl">Mattermost Url</span></th>
+            <th><span dojoTranslate="teamdojoApp.organization.countOfConfirmations">Count Of Confirmations</span></th>
             <th></th>
             </tr>
             </thead>
@@ -29,6 +30,7 @@
                 <td>{{organization.levelUpScore}}</td>
                 <td dojoTranslate="{{'teamdojoApp.UserMode.' + organization.userMode}}">{{organization.userMode}}</td>
                 <td>{{organization.mattermostUrl}}</td>
+                <td>{{organization.countOfConfirmations}}</td>
                 <td class="text-right">
                     <div class="btn-group flex-btn-group-container">
                         <button type="submit"

--- a/src/main/webapp/app/entities/team/team.component.html
+++ b/src/main/webapp/app/entities/team/team.component.html
@@ -14,7 +14,7 @@
         <table class="table table-striped">
             <thead>
             <tr jhiSort [(predicate)]="predicate" [(ascending)]="reverse" [callback]="reset.bind(this)">
-            <th jhiSortBy="id"><span dojoTranslate="global.field.id">ID</span> <span class="fa fa-sort"></span></th>
+            <th jhiSortBy="id"><span dojoTranslate="teamdojoApp.global.field.id">ID</span> <span class="fa fa-sort"></span></th>
             <th jhiSortBy="name"><span dojoTranslate="teamdojoApp.team.name">Name</span> <span class="fa fa-sort"></span></th>
             <th jhiSortBy="shortName"><span dojoTranslate="teamdojoApp.team.shortName">Short Name</span> <span class="fa fa-sort"></span></th>
             <th jhiSortBy="slogan"><span dojoTranslate="teamdojoApp.team.slogan">Slogan</span> <span class="fa fa-sort"></span></th>

--- a/src/main/webapp/app/entities/training/training-update.component.html
+++ b/src/main/webapp/app/entities/training/training-update.component.html
@@ -90,7 +90,7 @@
                     </div>
                 </div>
                 <div class="form-group">
-                    <label class="form-control-label" jhiTranslate="teamdojoApp.training.suggestedBy" for="field_suggestedBy">Suggested By</label>
+                    <label class="form-control-label" dojoTranslate="teamdojoApp.training.suggestedBy" for="field_suggestedBy">Suggested By</label>
                     <input type="text" class="form-control" name="suggestedBy" id="field_suggestedBy"
                         [(ngModel)]="training.suggestedBy" />
                 </div>

--- a/src/main/webapp/app/entities/training/training.component.html
+++ b/src/main/webapp/app/entities/training/training.component.html
@@ -14,7 +14,7 @@
         <table class="table table-striped">
             <thead>
             <tr jhiSort [(predicate)]="predicate" [(ascending)]="reverse" [callback]="reset.bind(this)">
-            <th jhiSortBy="id"><span dojoTranslate="global.field.id">ID</span> <fa-icon [icon]="'sort'"></fa-icon></th>
+            <th jhiSortBy="id"><span dojoTranslate="teamdojoApp.global.field.id">ID</span> <fa-icon [icon]="'sort'"></fa-icon></th>
             <th jhiSortBy="title"><span dojoTranslate="teamdojoApp.training.title">Title</span> <fa-icon [icon]="'sort'"></fa-icon></th>
             <th jhiSortBy="description"><span dojoTranslate="teamdojoApp.training.description">Description</span> <fa-icon [icon]="'sort'"></fa-icon></th>
             <th jhiSortBy="contactPerson"><span dojoTranslate="teamdojoApp.training.contactPerson">Contact Person</span> <fa-icon [icon]="'sort'"></fa-icon></th>

--- a/src/main/webapp/app/shared/model/organization.model.ts
+++ b/src/main/webapp/app/shared/model/organization.model.ts
@@ -9,6 +9,7 @@ export interface IOrganization {
     levelUpScore?: number;
     userMode?: UserMode;
     mattermostUrl?: string;
+    countOfConfirmations?: number;
 }
 
 export class Organization implements IOrganization {
@@ -17,6 +18,7 @@ export class Organization implements IOrganization {
         public name?: string,
         public levelUpScore?: number,
         public userMode?: UserMode,
-        public mattermostUrl?: string
+        public mattermostUrl?: string,
+        public countOfConfirmations?: number
     ) {}
 }

--- a/src/main/webapp/app/shared/number-input/number-input.component.html
+++ b/src/main/webapp/app/shared/number-input/number-input.component.html
@@ -4,10 +4,10 @@
     <input id="score-input" class="form-control score-input" type="number" name="score"
            [(ngModel)]="value"
            [min]="0" [required]="true" (click)="$event.stopPropagation();">
-    <button class="btn ml-1" type="button" (click)="update()" jhiTranslate="teamdojoApp.teams.skills.score.save">
+    <button class="btn ml-1" type="button" (click)="update()" dojoTranslate="teamdojoApp.teams.skills.score.save">
         OK
     </button>
-    <button class="btn ml-1" type="button" (click)="close()" jhiTranslate="teamdojoApp.teams.skills.score.cancel">
+    <button class="btn ml-1" type="button" (click)="close()" dojoTranslate="teamdojoApp.teams.skills.score.cancel">
         Cancel
     </button>
 </div>

--- a/src/main/webapp/app/shared/skill-details/skill-details-info.component.html
+++ b/src/main/webapp/app/shared/skill-details/skill-details-info.component.html
@@ -104,7 +104,7 @@
                         <a *ngIf="training.link" [href]="training.link" target="_blank">{{ training.title }}</a>
                         <span *ngIf="!training.link">{{ training.title }}</span> <small>({{ training.contactPerson }})</small>
                         <div *ngIf="training.suggestedBy">
-                            <small jhiTranslate="teamdojoApp.teams.skills.details.trainings.add.suggestedBy"></small><small>: {{ training.suggestedBy }}</small>
+                            <small dojoTranslate="teamdojoApp.teams.skills.details.trainings.add.suggestedBy"></small><small>: {{ training.suggestedBy }}</small>
                         </div>
                     </h6>
                     <p>{{ training.description }}</p>

--- a/src/main/webapp/app/shared/trainings/trainings-add.component.html
+++ b/src/main/webapp/app/shared/trainings/trainings-add.component.html
@@ -64,7 +64,7 @@
                         </div>
                     </div>
                     <div class="form-group">
-                        <label class="form-control-label" jhiTranslate="teamdojoApp.teams.skills.details.trainings.add.link" for="field_link">Link</label>
+                        <label class="form-control-label" dojoTranslate="teamdojoApp.teams.skills.details.trainings.add.link" for="field_link">Link</label>
                         <input type="text" class="form-control" name="link" id="field_link"
                                [(ngModel)]="training.link" maxlength="255"
                                pattern="^(?:http(s)?://)?[\w.-]+(?:\.[\w\.-]+)+[\w\-\._~:/?#\[\]@!\$&'\(\)\*\+,;=.]+$"/>

--- a/src/main/webapp/i18n/de/organization.json
+++ b/src/main/webapp/i18n/de/organization.json
@@ -18,7 +18,8 @@
             "name": "Name",
             "levelUpScore": "Level Up Score",
             "userMode": "User Mode",
-            "mattermostUrl": "Mattermost Url"
+            "mattermostUrl": "Mattermost Url",
+            "countOfConfirmations": "Count Of Confirmations"
         }
     }
 }

--- a/src/main/webapp/i18n/en/organization.json
+++ b/src/main/webapp/i18n/en/organization.json
@@ -18,7 +18,8 @@
             "name": "Name",
             "levelUpScore": "Level Up Score",
             "userMode": "User Mode",
-            "mattermostUrl": "Mattermost Url"
+            "mattermostUrl": "Mattermost Url",
+            "countOfConfirmations": "Count Of Confirmations"
         }
     }
 }

--- a/src/test/java/de/otto/teamdojo/web/rest/OrganizationResourceIntTest.java
+++ b/src/test/java/de/otto/teamdojo/web/rest/OrganizationResourceIntTest.java
@@ -56,6 +56,9 @@ public class OrganizationResourceIntTest {
     private static final String DEFAULT_MATTERMOST_URL = "-.u.CoT5";
     private static final String UPDATED_MATTERMOST_URL = "http://V.Zt.rPmr";
 
+    private static final Integer DEFAULT_COUNT_OF_CONFIRMATIONS = 0;
+    private static final Integer UPDATED_COUNT_OF_CONFIRMATIONS = 1;
+
     @Autowired
     private OrganizationRepository organizationRepository;
 
@@ -107,7 +110,8 @@ public class OrganizationResourceIntTest {
             .name(DEFAULT_NAME)
             .levelUpScore(DEFAULT_LEVEL_UP_SCORE)
             .userMode(DEFAULT_USER_MODE)
-            .mattermostUrl(DEFAULT_MATTERMOST_URL);
+            .mattermostUrl(DEFAULT_MATTERMOST_URL)
+            .countOfConfirmations(DEFAULT_COUNT_OF_CONFIRMATIONS);
         return organization;
     }
 
@@ -136,6 +140,7 @@ public class OrganizationResourceIntTest {
         assertThat(testOrganization.getLevelUpScore()).isEqualTo(DEFAULT_LEVEL_UP_SCORE);
         assertThat(testOrganization.getUserMode()).isEqualTo(DEFAULT_USER_MODE);
         assertThat(testOrganization.getMattermostUrl()).isEqualTo(DEFAULT_MATTERMOST_URL);
+        assertThat(testOrganization.getCountOfConfirmations()).isEqualTo(DEFAULT_COUNT_OF_CONFIRMATIONS);
     }
 
     @Test
@@ -210,7 +215,8 @@ public class OrganizationResourceIntTest {
             .andExpect(jsonPath("$.[*].name").value(hasItem(DEFAULT_NAME.toString())))
             .andExpect(jsonPath("$.[*].levelUpScore").value(hasItem(DEFAULT_LEVEL_UP_SCORE)))
             .andExpect(jsonPath("$.[*].userMode").value(hasItem(DEFAULT_USER_MODE.toString())))
-            .andExpect(jsonPath("$.[*].mattermostUrl").value(hasItem(DEFAULT_MATTERMOST_URL.toString())));
+            .andExpect(jsonPath("$.[*].mattermostUrl").value(hasItem(DEFAULT_MATTERMOST_URL.toString())))
+            .andExpect(jsonPath("$.[*].countOfConfirmations").value(hasItem(DEFAULT_COUNT_OF_CONFIRMATIONS)));
     }
     
     @Test
@@ -227,7 +233,8 @@ public class OrganizationResourceIntTest {
             .andExpect(jsonPath("$.name").value(DEFAULT_NAME.toString()))
             .andExpect(jsonPath("$.levelUpScore").value(DEFAULT_LEVEL_UP_SCORE))
             .andExpect(jsonPath("$.userMode").value(DEFAULT_USER_MODE.toString()))
-            .andExpect(jsonPath("$.mattermostUrl").value(DEFAULT_MATTERMOST_URL.toString()));
+            .andExpect(jsonPath("$.mattermostUrl").value(DEFAULT_MATTERMOST_URL.toString()))
+            .andExpect(jsonPath("$.countOfConfirmations").value(DEFAULT_COUNT_OF_CONFIRMATIONS));
     }
 
     @Test
@@ -254,7 +261,8 @@ public class OrganizationResourceIntTest {
             .name(UPDATED_NAME)
             .levelUpScore(UPDATED_LEVEL_UP_SCORE)
             .userMode(UPDATED_USER_MODE)
-            .mattermostUrl(UPDATED_MATTERMOST_URL);
+            .mattermostUrl(UPDATED_MATTERMOST_URL)
+            .countOfConfirmations(UPDATED_COUNT_OF_CONFIRMATIONS);
         OrganizationDTO organizationDTO = organizationMapper.toDto(updatedOrganization);
 
         restOrganizationMockMvc.perform(put("/api/organizations")
@@ -270,6 +278,7 @@ public class OrganizationResourceIntTest {
         assertThat(testOrganization.getLevelUpScore()).isEqualTo(UPDATED_LEVEL_UP_SCORE);
         assertThat(testOrganization.getUserMode()).isEqualTo(UPDATED_USER_MODE);
         assertThat(testOrganization.getMattermostUrl()).isEqualTo(UPDATED_MATTERMOST_URL);
+        assertThat(testOrganization.getCountOfConfirmations()).isEqualTo(UPDATED_COUNT_OF_CONFIRMATIONS);
     }
 
     @Test

--- a/src/test/javascript/spec/app/entities/organization/organization.service.spec.ts
+++ b/src/test/javascript/spec/app/entities/organization/organization.service.spec.ts
@@ -21,7 +21,7 @@ describe('Service Tests', () => {
             service = injector.get(OrganizationService);
             httpMock = injector.get(HttpTestingController);
 
-            elemDefault = new Organization(0, 'AAAAAAA', 0, UserMode.PERSON, 'AAAAAAA');
+            elemDefault = new Organization(0, 'AAAAAAA', 0, UserMode.PERSON, 'AAAAAAA', 0);
         });
 
         describe('Service methods', async () => {
@@ -58,7 +58,8 @@ describe('Service Tests', () => {
                         name: 'BBBBBB',
                         levelUpScore: 1,
                         userMode: 'BBBBBB',
-                        mattermostUrl: 'BBBBBB'
+                        mattermostUrl: 'BBBBBB',
+                        countOfConfirmations: 1
                     },
                     elemDefault
                 );
@@ -78,7 +79,8 @@ describe('Service Tests', () => {
                         name: 'BBBBBB',
                         levelUpScore: 1,
                         userMode: 'BBBBBB',
-                        mattermostUrl: 'BBBBBB'
+                        mattermostUrl: 'BBBBBB',
+                        countOfConfirmations: 1
                     },
                     elemDefault
                 );


### PR DESCRIPTION
This PR allows you to configure the number of confirmations required to achieve a skill. This means that only if X teams / persons have verified (up-voted) that a user has achieved a skill will this skill actually be verified.

But I think I have found a **bug** in the voting functionality so far: 
As soon as the x-th user has up-voted my skill, it should be displayed as verified (green) in the living room. However, this only happens if I first "reopen" the skill manually and then click on "complete" again.

I suppose this behaviour has to do with the ```TeamSkillVoteComponent``` (which is called when you follow the Mattermost link to vote [```#/team-skill/SKILL-ID/vote```]). The ```TeamSkillVoteComponent.upVote()``` method sends a PUT request to ```TeamSkillResource```.
But a skill can only be verified by ```AchievableSkillService``` so far.