### PR TITLE
Feature/edo 138 performance improvements

### DIFF
--- a/.jhipster/Image.json
+++ b/.jhipster/Image.json
@@ -24,12 +24,22 @@
             "fieldName": "large",
             "fieldType": "byte[]",
             "fieldTypeBlobContent": "image"
+        },
+        {
+            "fieldName": "hash",
+            "fieldType": "String",
+            "fieldValidateRules": [
+                "maxlength"
+            ],
+            "fieldValidateRulesMaxlength": "32"
         }
     ],
     "changelogDate": "20180605123508",
     "dto": "mapstruct",
+    "searchEngine": false,
     "service": "serviceImpl",
     "entityTableName": "image",
+    "databaseType": "sql",
     "jpaMetamodelFiltering": true,
     "pagination": "infinite-scroll"
 }

--- a/src/main/java/de/otto/teamdojo/domain/Image.java
+++ b/src/main/java/de/otto/teamdojo/domain/Image.java
@@ -50,6 +50,10 @@ public class Image implements Serializable {
     @Column(name = "large_content_type")
     private String largeContentType;
 
+    @Size(max = 32)
+    @Column(name = "hash", length = 32)
+    private String hash;
+
     // jhipster-needle-entity-add-field - JHipster will add fields here, do not remove
     public Long getId() {
         return id;
@@ -149,6 +153,19 @@ public class Image implements Serializable {
     public void setLargeContentType(String largeContentType) {
         this.largeContentType = largeContentType;
     }
+
+    public String getHash() {
+        return hash;
+    }
+
+    public Image hash(String hash) {
+        this.hash = hash;
+        return this;
+    }
+
+    public void setHash(String hash) {
+        this.hash = hash;
+    }
     // jhipster-needle-entity-add-getters-setters - JHipster will add getters and setters here, do not remove
 
     @Override
@@ -182,6 +199,7 @@ public class Image implements Serializable {
             ", mediumContentType='" + getMediumContentType() + "'" +
             ", large='" + getLarge() + "'" +
             ", largeContentType='" + getLargeContentType() + "'" +
+            ", hash='" + getHash() + "'" +
             "}";
     }
 }

--- a/src/main/java/de/otto/teamdojo/service/ImageQueryService.java
+++ b/src/main/java/de/otto/teamdojo/service/ImageQueryService.java
@@ -92,6 +92,9 @@ public class ImageQueryService extends QueryService<Image> {
             if (criteria.getName() != null) {
                 specification = specification.and(buildStringSpecification(criteria.getName(), Image_.name));
             }
+            if (criteria.getHash() != null) {
+                specification = specification.and(buildStringSpecification(criteria.getHash(), Image_.hash));
+            }
         }
         return specification;
     }

--- a/src/main/java/de/otto/teamdojo/service/ImageService.java
+++ b/src/main/java/de/otto/teamdojo/service/ImageService.java
@@ -4,6 +4,7 @@ import de.otto.teamdojo.service.dto.ImageDTO;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.security.NoSuchAlgorithmException;
 import java.util.Optional;
 
 /**
@@ -17,7 +18,7 @@ public interface ImageService {
      * @param imageDTO the entity to save
      * @return the persisted entity
      */
-    ImageDTO save(ImageDTO imageDTO);
+    ImageDTO save(ImageDTO imageDTO) throws NoSuchAlgorithmException;
 
     /**
      * Get all the images.

--- a/src/main/java/de/otto/teamdojo/service/dto/BadgeDTO.java
+++ b/src/main/java/de/otto/teamdojo/service/dto/BadgeDTO.java
@@ -41,6 +41,8 @@ public class BadgeDTO implements Serializable {
 
     private Long imageId;
 
+    private String imageHash;
+
     private String imageName;
 
     public Long getId() {
@@ -123,6 +125,14 @@ public class BadgeDTO implements Serializable {
         this.imageId = imageId;
     }
 
+    public String getImageHash() {
+        return imageHash;
+    }
+
+    public void setImageHash(String imageHash) {
+        this.imageHash = imageHash;
+    }
+
     public String getImageName() {
         return imageName;
     }
@@ -164,7 +174,8 @@ public class BadgeDTO implements Serializable {
             ", instantMultiplier=" + getInstantMultiplier() +
             ", completionBonus=" + getCompletionBonus() +
             ", image=" + getImageId() +
-            ", image='" + getImageName() + "'" +
+            ", imageName='" + getImageName() + "'" +
+            ", imageHash='" + getImageHash() + "'" +
             "}";
     }
 }

--- a/src/main/java/de/otto/teamdojo/service/dto/ImageCriteria.java
+++ b/src/main/java/de/otto/teamdojo/service/dto/ImageCriteria.java
@@ -26,6 +26,8 @@ public class ImageCriteria implements Serializable {
 
     private StringFilter name;
 
+    private StringFilter hash;
+
     public LongFilter getId() {
         return id;
     }
@@ -42,6 +44,14 @@ public class ImageCriteria implements Serializable {
         this.name = name;
     }
 
+    public StringFilter getHash() {
+        return hash;
+    }
+
+    public void setHash(StringFilter hash) {
+        this.hash = hash;
+    }
+
 
     @Override
     public boolean equals(Object o) {
@@ -54,14 +64,16 @@ public class ImageCriteria implements Serializable {
         final ImageCriteria that = (ImageCriteria) o;
         return
             Objects.equals(id, that.id) &&
-            Objects.equals(name, that.name);
+            Objects.equals(name, that.name) &&
+            Objects.equals(hash, that.hash);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(
         id,
-        name
+        name,
+        hash
         );
     }
 
@@ -70,6 +82,7 @@ public class ImageCriteria implements Serializable {
         return "ImageCriteria{" +
                 (id != null ? "id=" + id + ", " : "") +
                 (name != null ? "name=" + name + ", " : "") +
+                (hash != null ? "hash=" + hash + ", " : "") +
             "}";
     }
 

--- a/src/main/java/de/otto/teamdojo/service/dto/ImageDTO.java
+++ b/src/main/java/de/otto/teamdojo/service/dto/ImageDTO.java
@@ -26,6 +26,9 @@ public class ImageDTO implements Serializable {
     private byte[] large;
 
     private String largeContentType;
+    @Size(max = 32)
+    private String hash;
+
 
     public Long getId() {
         return id;
@@ -91,6 +94,14 @@ public class ImageDTO implements Serializable {
         this.largeContentType = largeContentType;
     }
 
+    public String getHash() {
+        return hash;
+    }
+
+    public void setHash(String hash) {
+        this.hash = hash;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -120,6 +131,7 @@ public class ImageDTO implements Serializable {
             ", small='" + getSmall() + "'" +
             ", medium='" + getMedium() + "'" +
             ", large='" + getLarge() + "'" +
+            ", hash='" + getHash() + "'" +
             "}";
     }
 }

--- a/src/main/java/de/otto/teamdojo/service/dto/LevelDTO.java
+++ b/src/main/java/de/otto/teamdojo/service/dto/LevelDTO.java
@@ -41,6 +41,8 @@ public class LevelDTO implements Serializable {
 
     private String imageName;
 
+    private String imageHash;
+
     public Long getId() {
         return id;
     }
@@ -137,6 +139,14 @@ public class LevelDTO implements Serializable {
         this.imageName = imageName;
     }
 
+    public String getImageHash() {
+        return imageHash;
+    }
+
+    public void setImageHash(String imageHash) {
+        this.imageHash = imageHash;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -172,7 +182,8 @@ public class LevelDTO implements Serializable {
             ", dependsOn=" + getDependsOnId() +
             ", dependsOn='" + getDependsOnName() + "'" +
             ", image=" + getImageId() +
-            ", image='" + getImageName() + "'" +
+            ", imageName='" + getImageName() + "'" +
+            ", imageHash='" + getImageHash() + "'" +
             "}";
     }
 }

--- a/src/main/java/de/otto/teamdojo/service/impl/ImageServiceImpl.java
+++ b/src/main/java/de/otto/teamdojo/service/impl/ImageServiceImpl.java
@@ -1,24 +1,26 @@
 package de.otto.teamdojo.service.impl;
 
-import de.otto.teamdojo.service.ImageService;
 import de.otto.teamdojo.domain.Image;
 import de.otto.teamdojo.repository.ImageRepository;
+import de.otto.teamdojo.service.ImageService;
 import de.otto.teamdojo.service.dto.ImageDTO;
 import de.otto.teamdojo.service.mapper.ImageMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.imageio.ImageIO;
+import javax.xml.bind.DatatypeConverter;
 import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.Optional;
 
 /**
@@ -51,7 +53,7 @@ public class ImageServiceImpl implements ImageService {
      * @return the persisted entity
      */
     @Override
-    public ImageDTO save(ImageDTO imageDTO) {
+    public ImageDTO save(ImageDTO imageDTO) throws NoSuchAlgorithmException {
         log.debug("Request to save Image : {}", imageDTO);
 
         byte[] imgByteArray = imageDTO.getLarge();
@@ -68,6 +70,12 @@ public class ImageServiceImpl implements ImageService {
             imageDTO.setSmall(getByteArrayFromBufferedImage(small));
             imageDTO.setSmallContentType(contentType);
         }
+
+        MessageDigest md = MessageDigest.getInstance("MD5");
+        byte[] imageDigest = md.digest(imageDTO.getLarge());
+        String hash = DatatypeConverter
+            .printHexBinary(imageDigest).toUpperCase();
+        imageDTO.setHash(hash);
 
         Image image = imageMapper.toEntity(imageDTO);
         image = imageRepository.save(image);

--- a/src/main/java/de/otto/teamdojo/service/mapper/BadgeMapper.java
+++ b/src/main/java/de/otto/teamdojo/service/mapper/BadgeMapper.java
@@ -13,6 +13,7 @@ public interface BadgeMapper extends EntityMapper<BadgeDTO, Badge> {
 
     @Mapping(source = "image.id", target = "imageId")
     @Mapping(source = "image.name", target = "imageName")
+    @Mapping(source = "image.hash", target = "imageHash")
     BadgeDTO toDto(Badge badge);
 
     @Mapping(target = "skills", ignore = true)

--- a/src/main/java/de/otto/teamdojo/service/mapper/LevelMapper.java
+++ b/src/main/java/de/otto/teamdojo/service/mapper/LevelMapper.java
@@ -17,6 +17,7 @@ public interface LevelMapper extends EntityMapper<LevelDTO, Level> {
     @Mapping(source = "dependsOn.name", target = "dependsOnName")
     @Mapping(source = "image.id", target = "imageId")
     @Mapping(source = "image.name", target = "imageName")
+    @Mapping(source = "image.hash", target = "imageHash")
     LevelDTO toDto(Level level);
 
     @Mapping(source = "dimensionId", target = "dimension")

--- a/src/main/java/de/otto/teamdojo/web/rest/ImageResource.java
+++ b/src/main/java/de/otto/teamdojo/web/rest/ImageResource.java
@@ -18,9 +18,12 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import javax.xml.bind.DatatypeConverter;
 import java.net.URI;
 import java.net.URISyntaxException;
 
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -53,7 +56,7 @@ public class ImageResource {
      * @throws URISyntaxException if the Location URI syntax is incorrect
      */
     @PostMapping("/images")
-    public ResponseEntity<ImageDTO> createImage(@Valid @RequestBody ImageDTO imageDTO) throws URISyntaxException {
+    public ResponseEntity<ImageDTO> createImage(@Valid @RequestBody ImageDTO imageDTO) throws URISyntaxException, NoSuchAlgorithmException {
         log.debug("REST request to save Image : {}", imageDTO);
         if (imageDTO.getId() != null) {
             throw new BadRequestAlertException("A new image cannot already have an ID", ENTITY_NAME, "idexists");
@@ -74,7 +77,7 @@ public class ImageResource {
      * @throws URISyntaxException if the Location URI syntax is incorrect
      */
     @PutMapping("/images")
-    public ResponseEntity<ImageDTO> updateImage(@Valid @RequestBody ImageDTO imageDTO) throws URISyntaxException {
+    public ResponseEntity<ImageDTO> updateImage(@Valid @RequestBody ImageDTO imageDTO) throws URISyntaxException, NoSuchAlgorithmException {
         log.debug("REST request to update Image : {}", imageDTO);
         if (imageDTO.getId() == null) {
             throw new BadRequestAlertException("Invalid id", ENTITY_NAME, "idnull");

--- a/src/main/resources/config/application-dev.yml
+++ b/src/main/resources/config/application-dev.yml
@@ -64,6 +64,10 @@ spring:
         cache-duration: PT1S # 1 second, see the ISO 8601 standard
     thymeleaf:
         cache: false
+    resources:
+        cache:
+            cachecontrol:
+                max-age: 365d
 
 server:
     port: 8080

--- a/src/main/resources/config/application-int.yml
+++ b/src/main/resources/config/application-int.yml
@@ -53,6 +53,10 @@ spring:
         password:
     thymeleaf:
         cache: true
+    resources:
+        cache:
+            cachecontrol:
+                max-age: 365d
 
 # ===================================================================
 # To enable TLS in production, generate a certificate using:

--- a/src/main/resources/config/application-prod.yml
+++ b/src/main/resources/config/application-prod.yml
@@ -53,6 +53,10 @@ spring:
         password:
     thymeleaf:
         cache: true
+    resources:
+        cache:
+            cachecontrol:
+                max-age: 365d
 
 # ===================================================================
 # To enable TLS in production, generate a certificate using:

--- a/src/main/resources/config/liquibase/changelog/20190304093000_add_hash_column_to_image.xml
+++ b/src/main/resources/config/liquibase/changelog/20190304093000_add_hash_column_to_image.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<databaseChangeLog
+    xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd
+                        http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+
+    <changeSet id="20190304093000-1" author="fbe">
+        <addColumn tableName="image">
+            <column name="hash" type="varchar(32)">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/master.xml
+++ b/src/main/resources/config/liquibase/master.xml
@@ -47,4 +47,5 @@
     <include file="config/liquibase/changelog/20190218115900_add_suggested_by_column_to_training.xml" relativeToChangelogFile="false"/>
 
     <include file="config/liquibase/changelog/20190226165530_add_default_images.xml" relativeToChangelogFile="false"/>
+    <include file="config/liquibase/changelog/20190304093000_add_hash_column_to_image.xml" relativeToChangelogFile="false"/>
 </databaseChangeLog>

--- a/src/main/webapp/app/entities/image/image-delete-dialog.component.html
+++ b/src/main/webapp/app/entities/image/image-delete-dialog.component.html
@@ -6,7 +6,7 @@
     </div>
     <div class="modal-body">
         <jhi-alert-error></jhi-alert-error>
-        <p dojoTranslate="teamdojoApp.image.delete.question" id="jhi-delete-image-heading"
+        <p id="jhi-delete-image-heading" dojoTranslate="teamdojoApp.image.delete.question"
            [translateValues]="{id: image.id}">Are you sure you want to delete this Image?</p>
     </div>
     <div class="modal-footer">

--- a/src/main/webapp/app/entities/image/image-detail.component.html
+++ b/src/main/webapp/app/entities/image/image-detail.component.html
@@ -36,6 +36,10 @@
                         {{image.largeContentType}}, {{byteSize(image.large)}}
                     </div>
                 </dd>
+                <dt><span dojoTranslate="teamdojoApp.image.hash">Hash</span></dt>
+                <dd>
+                    <span>{{image.hash}}</span>
+                </dd>
             </dl>
 
             <button type="submit"

--- a/src/main/webapp/app/entities/image/image-update.component.html
+++ b/src/main/webapp/app/entities/image/image-update.component.html
@@ -1,11 +1,11 @@
 <div class="row justify-content-center">
     <div class="col-8">
         <form name="editForm" role="form" novalidate (ngSubmit)="save()" #editForm="ngForm">
-            <h2 dojoTranslate="teamdojoApp.image.home.createOrEditLabel" id="jhi-image-heading">Create or edit a Image</h2>
+            <h2 id="jhi-image-heading" dojoTranslate="teamdojoApp.image.home.createOrEditLabel">Create or edit a Image</h2>
             <div>
                 <jhi-alert-error></jhi-alert-error>
                 <div class="form-group" [hidden]="!image.id">
-                    <label dojoTranslate="teamdojoApp.global.field.id" for="id">ID</label>
+                    <label for="id" dojoTranslate="teamdojoApp.global.field.id">ID</label>
                     <input type="text" class="form-control" id="id" name="id"
                         [(ngModel)]="image.id" readonly />
                 </div>
@@ -21,8 +21,7 @@
                     </div>
                 </div>
                 <div class="form-group">
-                    <label class="form-control-label" dojoTranslate="teamdojoApp.image.small"
-                           for="field_small">Small</label>
+                    <label class="form-control-label" dojoTranslate="teamdojoApp.image.small" for="field_small">Small</label>
                     <div>
                         <img [src]="'data:' + image.smallContentType + ';base64,' + image.small"
                              style="max-height: 100px;" *ngIf="image.small" alt="image image"/>
@@ -30,16 +29,16 @@
                             <span class="pull-left">{{image.smallContentType}}, {{byteSize(image.small)}}</span>
                             <button type="button" (click)="clearInputImage('small', 'smallContentType', 'fileImage')"
                                     class="btn btn-secondary btn-xs pull-right">
-                                <span class="fa fa-times"></span>
+                                <fa-icon [icon]="'times'"></fa-icon>
                             </button>
                         </div>
                         <input type="file" id="file_small" (change)="setFileData($event, image, 'small', true)"
                                accept="image/*" dojoTranslate="entity.action.addimage"/>
                     </div>
                     <input type="hidden" class="form-control" name="small" id="field_small"
-                           [(ngModel)]="image.small"/>
+                        [(ngModel)]="image.small" />
                     <input type="hidden" class="form-control" name="smallContentType" id="field_smallContentType"
-                           [(ngModel)]="image.smallContentType"/>
+                        [(ngModel)]="image.smallContentType" />
                 </div>
                 <div class="form-group">
                     <label class="form-control-label" dojoTranslate="teamdojoApp.image.medium"
@@ -51,16 +50,16 @@
                             <span class="pull-left">{{image.mediumContentType}}, {{byteSize(image.medium)}}</span>
                             <button type="button" (click)="clearInputImage('medium', 'mediumContentType', 'fileImage')"
                                     class="btn btn-secondary btn-xs pull-right">
-                                <span class="fa fa-times"></span>
+                                <fa-icon [icon]="'times'"></fa-icon>
                             </button>
                         </div>
                         <input type="file" id="file_medium" (change)="setFileData($event, image, 'medium', true)"
                                accept="image/*" dojoTranslate="entity.action.addimage"/>
                     </div>
                     <input type="hidden" class="form-control" name="medium" id="field_medium"
-                           [(ngModel)]="image.medium"/>
+                        [(ngModel)]="image.medium" />
                     <input type="hidden" class="form-control" name="mediumContentType" id="field_mediumContentType"
-                           [(ngModel)]="image.mediumContentType"/>
+                        [(ngModel)]="image.mediumContentType" />
                 </div>
                 <div class="form-group">
                     <label class="form-control-label" dojoTranslate="teamdojoApp.image.large" for="field_large">Large</label>
@@ -72,12 +71,23 @@
                                 <fa-icon [icon]="'times'"></fa-icon>
                             </button>
                         </div>
-                        <input (change)="setFileData($event, image, 'large', true)" accept="image/*" dojoTranslate="entity.action.addimage" id="file_large" type="file"/>
+                        <input type="file" id="file_large" (change)="setFileData($event, image, 'large', true)" accept="image/*" dojoTranslate="entity.action.addimage"/>
                     </div>
                     <input type="hidden" class="form-control" name="large" id="field_large"
-                           [(ngModel)]="image.large" />
+                        [(ngModel)]="image.large" />
                     <input type="hidden" class="form-control" name="largeContentType" id="field_largeContentType"
-                           [(ngModel)]="image.largeContentType" />
+                        [(ngModel)]="image.largeContentType" />
+                </div>
+                <div class="form-group">
+                    <label class="form-control-label" dojoTranslate="teamdojoApp.image.hash" for="field_hash">Hash</label>
+                    <input type="text" class="form-control" name="hash" id="field_hash"
+                        [(ngModel)]="image.hash" maxlength="32"/>
+                    <div [hidden]="!(editForm.controls.hash?.dirty && editForm.controls.hash?.invalid)">
+                        <small class="form-text text-danger"
+                        [hidden]="!editForm.controls.hash?.errors?.maxlength" dojoTranslate="entity.validation.maxlength" [translateValues]="{ max: 32 }">
+                        This field cannot be longer than 32 characters.
+                        </small>
+                    </div>
                 </div>
 
             </div>

--- a/src/main/webapp/app/entities/image/image.component.html
+++ b/src/main/webapp/app/entities/image/image.component.html
@@ -14,16 +14,12 @@
         <table class="table table-striped">
             <thead>
             <tr jhiSort [(predicate)]="predicate" [(ascending)]="reverse" [callback]="reset.bind(this)">
-                <th jhiSortBy="id"><span dojoTranslate="teamdojoApp.global.field.id">ID</span> <span
-                    class="fa fa-sort"></span></th>
-                <th jhiSortBy="name"><span dojoTranslate="teamdojoApp.image.name">Name</span> <span
-                    class="fa fa-sort"></span></th>
-                <th jhiSortBy="small"><span dojoTranslate="teamdojoApp.image.small">Small</span> <span
-                    class="fa fa-sort"></span></th>
-                <th jhiSortBy="medium"><span dojoTranslate="teamdojoApp.image.medium">Medium</span> <span
-                    class="fa fa-sort"></span></th>
-                <th jhiSortBy="large"><span dojoTranslate="teamdojoApp.image.large">Large</span> <span
-                    class="fa fa-sort"></span></th>
+            <th jhiSortBy="id"><span dojoTranslate="global.field.id">ID</span> <fa-icon [icon]="'sort'"></fa-icon></th>
+            <th jhiSortBy="name"><span dojoTranslate="teamdojoApp.image.name">Name</span> <fa-icon [icon]="'sort'"></fa-icon></th>
+            <th jhiSortBy="small"><span dojoTranslate="teamdojoApp.image.small">Small</span> <fa-icon [icon]="'sort'"></fa-icon></th>
+            <th jhiSortBy="medium"><span dojoTranslate="teamdojoApp.image.medium">Medium</span> <fa-icon [icon]="'sort'"></fa-icon></th>
+            <th jhiSortBy="large"><span dojoTranslate="teamdojoApp.image.large">Large</span> <fa-icon [icon]="'sort'"></fa-icon></th>
+            <th jhiSortBy="hash"><span dojoTranslate="teamdojoApp.image.hash">Hash</span> <fa-icon [icon]="'sort'"></fa-icon></th>
             <th></th>
             </tr>
             </thead>

--- a/src/main/webapp/app/layouts/navbar/navbar.component.html
+++ b/src/main/webapp/app/layouts/navbar/navbar.component.html
@@ -163,12 +163,6 @@
                             <span dojoTranslate="teamdojoApp.global.menu.entities.training">Training</span>
                         </a>
                     </li>
-                    <li>
-                        <a class="dropdown-item" routerLink="image" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }" (click)="collapseNavbar()">
-                            <fa-icon icon="asterisk" fixedWidth="true"></fa-icon>
-                            <span dojoTranslate="teamdojoApp.global.menu.entities.image">Image</span>
-                        </a>
-                    </li>
                     <!-- jhipster-needle-add-entity-to-menu - JHipster will add entities to the menu here -->
                 </ul>
             </li>

--- a/src/main/webapp/app/layouts/navbar/navbar.component.html
+++ b/src/main/webapp/app/layouts/navbar/navbar.component.html
@@ -163,6 +163,12 @@
                             <span dojoTranslate="teamdojoApp.global.menu.entities.training">Training</span>
                         </a>
                     </li>
+                    <li>
+                        <a class="dropdown-item" routerLink="image" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }" (click)="collapseNavbar()">
+                            <fa-icon icon="asterisk" fixedWidth="true"></fa-icon>
+                            <span dojoTranslate="teamdojoApp.global.menu.entities.image">Image</span>
+                        </a>
+                    </li>
                     <!-- jhipster-needle-add-entity-to-menu - JHipster will add entities to the menu here -->
                 </ul>
             </li>

--- a/src/main/webapp/app/shared/achievement/item/achievement-item.component.html
+++ b/src/main/webapp/app/shared/achievement/item/achievement-item.component.html
@@ -18,11 +18,10 @@
            {{('teamdojoApp.teams.achievements.item.multiplier' | translate) + ': ' + item.instantMultiplier}}
         </span>
     </div>
-
     <div class="item-content d-flex justify-content-center" [ngStyle]="{'width': size, 'height': size}">
         <span class="item-image">
             <img *ngIf="item.imageId ; else picturePlaceholder" [title]="item.name"
-                 [src]="item.imageId | imageUrl: 'medium'" class="mx-auto"/>
+                 [src]="item.imageId | imageUrl: 'medium' : item.imageHash ? item.imageHash : item.imageId" class="mx-auto"/>
             <ng-template #picturePlaceholder>
                 <span class="img-placeholder">{{item.name | truncateString}}</span>
             </ng-template>

--- a/src/main/webapp/app/shared/model/badge.model.ts
+++ b/src/main/webapp/app/shared/model/badge.model.ts
@@ -15,6 +15,7 @@ export interface IBadge {
     dimensions?: IDimension[];
     imageName?: string;
     imageId?: number;
+    imageHash?: string;
 }
 
 export class Badge implements IBadge {
@@ -30,6 +31,7 @@ export class Badge implements IBadge {
         public skills?: IBadgeSkill[],
         public dimensions?: IDimension[],
         public imageName?: string,
-        public imageId?: number
+        public imageId?: number,
+        public imageHash?: string
     ) {}
 }

--- a/src/main/webapp/app/shared/model/image.model.ts
+++ b/src/main/webapp/app/shared/model/image.model.ts
@@ -7,6 +7,7 @@ export interface IImage {
     medium?: any;
     largeContentType?: string;
     large?: any;
+    hash?: string;
 }
 
 export class Image implements IImage {
@@ -18,6 +19,7 @@ export class Image implements IImage {
         public mediumContentType?: string,
         public medium?: any,
         public largeContentType?: string,
-        public large?: any
+        public large?: any,
+        public hash?: string
     ) {}
 }

--- a/src/main/webapp/app/shared/model/level.model.ts
+++ b/src/main/webapp/app/shared/model/level.model.ts
@@ -14,6 +14,7 @@ export interface ILevel {
     skills?: ILevelSkill[];
     imageName?: string;
     imageId?: number;
+    imageHash?: string;
 }
 
 export class Level implements ILevel {
@@ -30,6 +31,7 @@ export class Level implements ILevel {
         public dependsOnId?: number,
         public skills?: ILevelSkill[],
         public imageName?: string,
-        public imageId?: number
+        public imageId?: number,
+        public imageHash?: string
     ) {}
 }

--- a/src/main/webapp/i18n/de/image.json
+++ b/src/main/webapp/i18n/de/image.json
@@ -18,7 +18,8 @@
             "name": "Name",
             "small": "Small",
             "medium": "Medium",
-            "large": "Large"
+            "large": "Large",
+            "hash": "Hash"
         }
     }
 }

--- a/src/main/webapp/i18n/en/image.json
+++ b/src/main/webapp/i18n/en/image.json
@@ -18,7 +18,8 @@
             "name": "Name",
             "small": "Small",
             "medium": "Medium",
-            "large": "Large"
+            "large": "Large",
+            "hash": "Hash"
         }
     }
 }

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -9,9 +9,9 @@
     <meta name="google" value="notranslate">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="theme-color" content="#000000">
-    <link rel="shortcut icon preload" href="favicon.ico?v=2" />
+    <link rel="shortcut icon" href="favicon.ico?v=2">
     <link rel="manifest preload" href="manifest.webapp" />
-    <link rel="stylesheet preload" href="content/css/loading.css">
+    <link rel="stylesheet preload" href="content/css/loading.css" as="style">
     <!-- jhipster-needle-add-resources-to-root - JHipster will add new resources here -->
 </head>
 <body>

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -9,9 +9,9 @@
     <meta name="google" value="notranslate">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="theme-color" content="#000000">
-    <link rel="shortcut icon" href="favicon.ico?v=2" />
-    <link rel="manifest" href="manifest.webapp" />
-    <link rel="stylesheet" href="content/css/loading.css">
+    <link rel="shortcut icon preload" href="favicon.ico?v=2" />
+    <link rel="manifest preload" href="manifest.webapp" />
+    <link rel="stylesheet preload" href="content/css/loading.css">
     <!-- jhipster-needle-add-resources-to-root - JHipster will add new resources here -->
 </head>
 <body>

--- a/src/test/javascript/spec/app/entities/image/image.component.spec.ts
+++ b/src/test/javascript/spec/app/entities/image/image.component.spec.ts
@@ -2,6 +2,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Observable, of } from 'rxjs';
 import { HttpHeaders, HttpResponse } from '@angular/common/http';
+import { ActivatedRoute, Data } from '@angular/router';
 
 import { TeamdojoTestModule } from '../../../test.module';
 import { ImageComponent } from 'app/entities/image/image.component';
@@ -18,7 +19,23 @@ describe('Component Tests', () => {
             TestBed.configureTestingModule({
                 imports: [TeamdojoTestModule],
                 declarations: [ImageComponent],
-                providers: []
+                providers: [
+                    {
+                        provide: ActivatedRoute,
+                        useValue: {
+                            data: {
+                                subscribe: (fn: (value: Data) => void) =>
+                                    fn({
+                                        pagingParams: {
+                                            predicate: 'id',
+                                            reverse: false,
+                                            page: 0
+                                        }
+                                    })
+                            }
+                        }
+                    }
+                ]
             })
                 .overrideTemplate(ImageComponent, '')
                 .compileComponents();
@@ -46,6 +63,66 @@ describe('Component Tests', () => {
             // THEN
             expect(service.query).toHaveBeenCalled();
             expect(comp.images[0]).toEqual(jasmine.objectContaining({ id: 123 }));
+        });
+
+        it('should load a page', () => {
+            // GIVEN
+            const headers = new HttpHeaders().append('link', 'link;link');
+            spyOn(service, 'query').and.returnValue(
+                of(
+                    new HttpResponse({
+                        body: [new Image(123)],
+                        headers
+                    })
+                )
+            );
+
+            // WHEN
+            comp.loadPage(1);
+
+            // THEN
+            expect(service.query).toHaveBeenCalled();
+            expect(comp.images[0]).toEqual(jasmine.objectContaining({ id: 123 }));
+        });
+
+        it('should re-initialize the page', () => {
+            // GIVEN
+            const headers = new HttpHeaders().append('link', 'link;link');
+            spyOn(service, 'query').and.returnValue(
+                of(
+                    new HttpResponse({
+                        body: [new Image(123)],
+                        headers
+                    })
+                )
+            );
+
+            // WHEN
+            comp.loadPage(1);
+            comp.reset();
+
+            // THEN
+            expect(comp.page).toEqual(0);
+            expect(service.query).toHaveBeenCalledTimes(2);
+            expect(comp.images[0]).toEqual(jasmine.objectContaining({ id: 123 }));
+        });
+        it('should calculate the sort attribute for an id', () => {
+            // WHEN
+            const result = comp.sort();
+
+            // THEN
+            expect(result).toEqual(['id,asc']);
+        });
+
+        it('should calculate the sort attribute for a non-id attribute', () => {
+            // GIVEN
+            comp.predicate = 'name';
+
+            // WHEN
+            const result = comp.sort();
+
+            // THEN
+            expect(result).toEqual(['name,asc', 'id']);
         });
     });
 });

--- a/src/test/javascript/spec/app/entities/image/image.service.spec.ts
+++ b/src/test/javascript/spec/app/entities/image/image.service.spec.ts
@@ -21,7 +21,7 @@ describe('Service Tests', () => {
             service = injector.get(ImageService);
             httpMock = injector.get(HttpTestingController);
 
-            elemDefault = new Image(0, 'AAAAAAA', 'image/png', 'AAAAAAA', 'image/png', 'AAAAAAA', 'image/png', 'AAAAAAA');
+            elemDefault = new Image(0, 'AAAAAAA', 'image/png', 'AAAAAAA', 'image/png', 'AAAAAAA', 'image/png', 'AAAAAAA', 'AAAAAAA');
         });
 
         describe('Service methods', async () => {
@@ -58,7 +58,8 @@ describe('Service Tests', () => {
                         name: 'BBBBBB',
                         small: 'BBBBBB',
                         medium: 'BBBBBB',
-                        large: 'BBBBBB'
+                        large: 'BBBBBB',
+                        hash: 'BBBBBB'
                     },
                     elemDefault
                 );
@@ -78,7 +79,8 @@ describe('Service Tests', () => {
                         name: 'BBBBBB',
                         small: 'BBBBBB',
                         medium: 'BBBBBB',
-                        large: 'BBBBBB'
+                        large: 'BBBBBB',
+                        hash: 'BBBBBB'
                     },
                     elemDefault
                 );


### PR DESCRIPTION
The following improvements have been utilized

- preload static resources
- Add cache-control header 'max-age'
- Add cacheBuster to Badge- & Levelimages

To verify the benefit of this PR more precisely, the local TeamDojo instance could be launched with the configuration of the PROD instances (e.g. to enable AOT). Therefore the contents of application-dev.yml & webpack.dev.js have to be replaced with the configurations for PROD environment.